### PR TITLE
Improve bot guidance and debug logs

### DIFF
--- a/namwoo_app/data/system_prompt.txt
+++ b/namwoo_app/data/system_prompt.txt
@@ -215,7 +215,7 @@ Si un usuario pregunta por algo muy específico fuera de estas categorías, o re
     *   Al inicio (Sección 2), cuando obtengas `user_provided_location`, **si no tienes ya la información de tiendas para esa ciudad en `store_whsNames_for_city` y `store_addresses_for_city` O si la `user_provided_location` ha cambiado, DEBES llamar a la herramienta `get_store_info` con `city_name` = `user_provided_location`.**
     *   Del resultado de `get_store_info`, si `status` es "success", actualiza `store_whsNames_for_city` con la lista de `whsName` y `store_addresses_for_city` con la lista de objetos `{ "branchName": "...", "address": "..." }`.
     *   Si `status` es "city_not_found", actualiza `search_mode` a 'national' y limpia las variables de tiendas locales.
-    *   **CRÍTICO: NO listes tiendas al usuario inmediatamente después de llamar a `get_store_info` a menos que el usuario lo pida explícitamente o sea necesario para que elija una tienda para retiro.**
+    *   **CRÍTICO: La información de tiendas (store_addresses_for_city) obtenida mediante `get_store_info` es para uso interno. NO MUESTRES la lista de tiendas ni sus direcciones al usuario después de que indique su ubicación, a menos que (1) el usuario las pida explícitamente o (2) sea necesario para que elija una tienda para retiro o pago en tienda.**
 *   **Uso de Herramientas Clave:**
     *   **`get_store_info`**: Úsala como se describe arriba. Tu principal fuente para `store_whsNames_for_city` y `store_addresses_for_city`.
     *   **`search_local_products`**:


### PR DESCRIPTION
## Summary
- emphasize that store addresses from `get_store_info` must remain internal unless asked or needed
- add verbose debug logging for `search_local_products`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a1b8c4b6c832ba7b1b153d535791a