### PR TITLE
Fix store info disclosure

### DIFF
--- a/namwoo_app/data/system_prompt.txt
+++ b/namwoo_app/data/system_prompt.txt
@@ -68,6 +68,7 @@ Si un usuario pregunta por algo muy específico fuera de estas categorías, o re
         *   Puebla `store_whsNames_for_city` con la lista de `whsName` de las `stores` devueltas.
         *   Puebla `store_addresses_for_city` con la lista de objetos que contienen `address` y `branchName` de las `stores` devueltas.
         *   **Importante:** NO listes estas tiendas al usuario todavía a menos que él las solicite o sea necesario para que elija una tienda de retiro más adelante.
+        *   **Después de guardar esta información**, responde únicamente: "¡Entendido! Gracias por indicarme que estás en [user_provided_location]." **No menciones direcciones ni nombres de tiendas salvo que el usuario lo pida.**
     *   Si llamaste a `get_store_info` y la herramienta devuelve `status: "city_not_found"`:
         *   Actualiza `search_mode` a 'national'. Limpia `store_whsNames_for_city` y `store_addresses_for_city`.
         *   Responde: "Parece que no tenemos tiendas directamente en [user_provided_location]. La herramienta me indica que las ciudades con tiendas son: [lista de `available_cities` devuelta por la herramienta]. ¿Te gustaría que busque el producto que te interesa a nivel nacional o prefieres indicarme otra ciudad cercana donde podríamos tener tiendas?"

--- a/namwoo_app/services/product_service.py
+++ b/namwoo_app/services/product_service.py
@@ -166,10 +166,27 @@ def search_local_products(
                     "llm_formatted_description": prod_location_entry.format_for_llm() 
                 })
                 results.append(item_dict)
+            if not results and filter_stock:
+                logger.info(
+                    "No products found with stock filter applied. Retrying without stock filter for reference."
+                )
+                return search_local_products(
+                    query_text,
+                    limit=limit,
+                    filter_stock=False,
+                    min_score=min_score,
+                    warehouse_names=warehouse_names,
+                    min_price=min_price,
+                    max_price=max_price,
+                )
             if not results:
-                logger.info("Vector search completed but no products matched the criteria.")
+                logger.info(
+                    "Vector search completed but no products matched the criteria."
+                )
             else:
-                logger.info("Vector search returned %d product location entries.", len(results))
+                logger.info(
+                    "Vector search returned %d product location entries.", len(results)
+                )
             return results
         except SQLAlchemyError as db_exc:
             logger.exception("Database error during product search: %s", db_exc)


### PR DESCRIPTION
## Summary
- clarify in system prompt not to reveal store addresses after city is provided
- retry search without stock filter when nothing is found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a1f4e312c832ba0ec15f5a8b02c7a