### PR TITLE
Fix warehouse name canonicalization

### DIFF
--- a/migrations/2024Q2_canonicalise_whs_names.sql
+++ b/migrations/2024Q2_canonicalise_whs_names.sql
@@ -1,0 +1,11 @@
+-- Enable accent removal extension (safe if already present)
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Canonicalise warehouse_name column
+UPDATE products
+SET warehouse_name = UPPER(unaccent(warehouse_name));
+
+-- Rebuild composite IDs with canonicalised warehouse names
+UPDATE products
+SET id = item_code || '_' ||
+         REGEXP_REPLACE(warehouse_name, '[^A-Z0-9_-]', '_', 'g');

--- a/namwoo_app/utils/string_utils.py
+++ b/namwoo_app/utils/string_utils.py
@@ -1,0 +1,15 @@
+"""
+Lightweight helpers for common string normalisation.
+"""
+import unicodedata
+from typing import Optional
+
+
+def canonicalize_whs_name(name: str | None) -> Optional[str]:
+    """Convert a warehouse name to its canonical internal form."""
+    if not name:
+        return None
+    cleaned = unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode()
+    cleaned = cleaned.strip().upper()
+    return cleaned or None
+


### PR DESCRIPTION
## Summary
- add warehouse name canonicalization helper
- canonicalize warehouse names at ingest and search time
- reduce diagnostic log chatter
- SQL migration to canonicalize existing data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a2b61ad60832ba2e1d96dbec809d7