### PR TITLE
Implement warehouse canonical column logic

### DIFF
--- a/namwoo_app/models/product.py
+++ b/namwoo_app/models/product.py
@@ -1,86 +1,154 @@
 # namwoo_app/models/product.py
 import logging
-import re # For whitespace normalization in prepare_text_for_embedding
+import re  # For whitespace normalization in prepare_text_for_embedding
+from typing import Any, Dict, List, Optional  # Added List, Any
+
+from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
-    Column, String, Text, TIMESTAMP, func, UniqueConstraint, Integer, NUMERIC
+    NUMERIC,
+    TIMESTAMP,
+    Column,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    func,
 )
 from sqlalchemy.dialects.postgresql import JSONB
-from pgvector.sqlalchemy import Vector
-from typing import Dict, Optional, List, Any # Added List, Any
 
-from . import Base # Assuming Base is defined in models/__init__.py
 from ..config import Config
-from ..utils.text_utils import strip_html_to_text # Ensure this utility exists and works
+from ..utils.text_utils import (
+    strip_html_to_text,
+)  # Ensure this utility exists and works
+from . import Base  # Assuming Base is defined in models/__init__.py
 
 logger = logging.getLogger(__name__)
 
+
 class Product(Base):
-    __tablename__ = 'products'
+    __tablename__ = "products"
 
     # Composite Primary Key
-    id = Column(String(512), primary_key=True, index=True, comment="Composite ID: item_code + sanitized warehouse_name")
+    id = Column(
+        String(512),
+        primary_key=True,
+        index=True,
+        comment="Composite ID: item_code + sanitized warehouse_name",
+    )
 
     # Core product details
-    item_code = Column(String(64), nullable=False, index=True, comment="Original item code from Damasco")
+    item_code = Column(
+        String(64),
+        nullable=False,
+        index=True,
+        comment="Original item code from Damasco",
+    )
     item_name = Column(Text, nullable=False, comment="Product's full name or title")
-    
+
     # Descriptions
-    description = Column(Text, nullable=True, comment="Raw HTML product description from Damasco")
-    llm_summarized_description = Column(Text, nullable=True, comment="LLM-generated summary of the description")
+    description = Column(
+        Text, nullable=True, comment="Raw HTML product description from Damasco"
+    )
+    llm_summarized_description = Column(
+        Text, nullable=True, comment="LLM-generated summary of the description"
+    )
 
     # Descriptive attributes
-    category = Column(String(128), index=True, nullable=True) # Ensuring all text fields can be nullable
+    category = Column(
+        String(128), index=True, nullable=True
+    )  # Ensuring all text fields can be nullable
     sub_category = Column(String(128), index=True, nullable=True)
     brand = Column(String(128), index=True, nullable=True)
     line = Column(String(128), nullable=True, comment="Product line, if available")
-    item_group_name = Column(String(128), index=True, nullable=True, comment="Broader group name")
+    item_group_name = Column(
+        String(128), index=True, nullable=True, comment="Broader group name"
+    )
 
     # Location-specific attributes
-    warehouse_name = Column(String(255), nullable=False, index=True, comment="Warehouse name") # Part of PK logic, so must be non-null
+    warehouse_name = Column(
+        String(255), nullable=False, index=True, comment="Warehouse name"
+    )
+    warehouse_name_canonical = Column(String(255), nullable=False)
     branch_name = Column(String(255), index=True, nullable=True, comment="Branch name")
-    
+
     # Financial and stock
-    price = Column(NUMERIC(12, 2), nullable=True, comment="Price, typically in primary currency (e.g., USD)")
-    price_bolivar = Column(NUMERIC(12, 2), nullable=True, comment="Price in Bolívares (Bs.)") # <<< NEW FIELD ADDED
-    stock = Column(Integer, default=0, nullable=False) # Stock should have a default and be non-null
-    
+    price = Column(
+        NUMERIC(12, 2),
+        nullable=True,
+        comment="Price, typically in primary currency (e.g., USD)",
+    )
+    price_bolivar = Column(
+        NUMERIC(12, 2), nullable=True, comment="Price in Bolívares (Bs.)"
+    )  # <<< NEW FIELD ADDED
+    stock = Column(
+        Integer, default=0, nullable=False
+    )  # Stock should have a default and be non-null
+
     # Embedding related fields
-    searchable_text_content = Column(Text, nullable=True, comment="PLAIN TEXT content used to generate the embedding")
-    embedding = Column(Vector(Config.EMBEDDING_DIMENSION if hasattr(Config, 'EMBEDDING_DIMENSION') and Config.EMBEDDING_DIMENSION else 1536), nullable=True, comment="pgvector embedding") 
-    
+    searchable_text_content = Column(
+        Text, nullable=True, comment="PLAIN TEXT content used to generate the embedding"
+    )
+    embedding = Column(
+        Vector(
+            Config.EMBEDDING_DIMENSION
+            if hasattr(Config, "EMBEDDING_DIMENSION") and Config.EMBEDDING_DIMENSION
+            else 1536
+        ),
+        nullable=True,
+        comment="pgvector embedding",
+    )
+
     # Auditing
-    source_data_json = Column(JSONB, nullable=True, comment="Original JSON data for this entry from Damasco") # Changed default from {} to nullable=True
-    
+    source_data_json = Column(
+        JSONB, nullable=True, comment="Original JSON data for this entry from Damasco"
+    )  # Changed default from {} to nullable=True
+
     # Timestamps
-    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
+    created_at = Column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
 
     __table_args__ = (
-        UniqueConstraint('item_code', 'warehouse_name', name='uq_item_code_per_warehouse'),
+        UniqueConstraint(
+            "item_code", "warehouse_name_canonical", name="uq_item_code_whs_canon"
+        ),
     )
 
     def __repr__(self):
-        return (f"<Product(id='{self.id}', item_name='{self.item_name[:30]}...', "
-                f"warehouse='{self.warehouse_name}', stock={self.stock})>")
+        return (
+            f"<Product(id='{self.id}', item_name='{self.item_name[:30]}...', "
+            f"warehouse='{self.warehouse_name}', stock={self.stock})>"
+        )
 
-    def to_dict(self) -> Dict[str, Any]: # Explicitly typing return dict
+    def to_dict(self) -> Dict[str, Any]:  # Explicitly typing return dict
         """Returns a dictionary representation of the product-location entry."""
         return {
             "id": self.id,
             "item_code": self.item_code,
             "item_name": self.item_name,
-            "description": self.description, 
+            "description": self.description,
             "llm_summarized_description": self.llm_summarized_description,
-            "plain_text_description_derived": strip_html_to_text(self.description or ""),
+            "plain_text_description_derived": strip_html_to_text(
+                self.description or ""
+            ),
             "category": self.category,
             "sub_category": self.sub_category,
             "brand": self.brand,
             "line": self.line,
             "item_group_name": self.item_group_name,
             "warehouse_name": self.warehouse_name,
+            "warehouse_name_canonical": self.warehouse_name_canonical,
             "branch_name": self.branch_name,
             "price": float(self.price) if self.price is not None else None,
-            "price_bolivar": float(self.price_bolivar) if self.price_bolivar is not None else None, # <<< NEW FIELD ADDED
+            "price_bolivar": (
+                float(self.price_bolivar) if self.price_bolivar is not None else None
+            ),  # <<< NEW FIELD ADDED
             "stock": self.stock,
             "searchable_text_content": self.searchable_text_content,
             # "source_data_json": self.source_data_json, # Often too verbose for general dicts unless specifically requested
@@ -90,39 +158,61 @@ class Product(Base):
 
     def format_for_llm(self, include_stock_location: bool = True) -> str:
         """Formats product information for presentation by an LLM, prioritizing LLM summary."""
-        price_str = f"${float(self.price):.2f}" if self.price is not None else "Precio no disponible"
+        price_str = (
+            f"${float(self.price):.2f}"
+            if self.price is not None
+            else "Precio no disponible"
+        )
         # <<< OPTIONAL: Add price_bolivar display here >>>
-        price_bolivar_str = f" (Bs. {float(self.price_bolivar):.2f})" if self.price_bolivar is not None else ""
-        
+        price_bolivar_str = (
+            f" (Bs. {float(self.price_bolivar):.2f})"
+            if self.price_bolivar is not None
+            else ""
+        )
+
         current_description_text = ""
-        if self.llm_summarized_description and self.llm_summarized_description.strip(): # Check if not empty
+        if (
+            self.llm_summarized_description and self.llm_summarized_description.strip()
+        ):  # Check if not empty
             current_description_text = self.llm_summarized_description.strip()
-        elif self.description: 
+        elif self.description:
             stripped_desc = strip_html_to_text(self.description)
-            if stripped_desc and stripped_desc.strip(): # Check if not empty after stripping
-                 current_description_text = stripped_desc.strip()
-        
-        desc_str_for_llm = f"Descripción: {current_description_text}" if current_description_text else "Descripción no disponible."
-        
-        base_info = (f"{self.item_name or 'Producto sin nombre'} "
-                     f"(Marca: {self.brand or 'N/A'}, "
-                     f"Categoría: {self.category or 'N/A'}). "
-                     f"{price_str}{price_bolivar_str}. {desc_str_for_llm}") # <<< MODIFIED to include price_bolivar_str
-        
+            if (
+                stripped_desc and stripped_desc.strip()
+            ):  # Check if not empty after stripping
+                current_description_text = stripped_desc.strip()
+
+        desc_str_for_llm = (
+            f"Descripción: {current_description_text}"
+            if current_description_text
+            else "Descripción no disponible."
+        )
+
+        base_info = (
+            f"{self.item_name or 'Producto sin nombre'} "
+            f"(Marca: {self.brand or 'N/A'}, "
+            f"Categoría: {self.category or 'N/A'}). "
+            f"{price_str}{price_bolivar_str}. {desc_str_for_llm}"
+        )  # <<< MODIFIED to include price_bolivar_str
+
         if include_stock_location:
             stock_str = f"Stock: {self.stock if self.stock is not None else 'N/A'}"
-            location_str = f"Disponible en {self.warehouse_name or 'ubicación desconocida'}"
+            location_str = (
+                f"Disponible en {self.warehouse_name or 'ubicación desconocida'}"
+            )
             if self.branch_name and self.branch_name != self.warehouse_name:
                 location_str += f" (Sucursal: {self.branch_name})"
             return f"{base_info} {location_str}. {stock_str}."
         return base_info.strip()
 
-    @classmethod # Or @staticmethod if cls is not used internally by this method
+    @classmethod  # Or @staticmethod if cls is not used internally by this method
     def prepare_text_for_embedding(
-        cls, # Added cls for classmethod convention
-        damasco_product_data: Dict[str, Any], 
+        cls,  # Added cls for classmethod convention
+        damasco_product_data: Dict[str, Any],
         llm_generated_summary: Optional[str],
-        raw_html_description_for_fallback: Optional[str] # <<< MODIFIED: ADDED THIS ARGUMENT
+        raw_html_description_for_fallback: Optional[
+            str
+        ],  # <<< MODIFIED: ADDED THIS ARGUMENT
     ) -> Optional[str]:
         """
         Constructs and cleans the text string for semantic embeddings.
@@ -131,19 +221,21 @@ class Product(Base):
         Expects damasco_product_data keys to be camelCase.
         """
         description_content_for_embedding = ""
-        
+
         # Priority 1: Use provided LLM summary if it's not None and not empty after stripping
         if llm_generated_summary and llm_generated_summary.strip():
             description_content_for_embedding = llm_generated_summary.lower().strip()
         # Priority 2: Fallback to stripping the provided raw HTML description
-        elif raw_html_description_for_fallback: # Check if fallback HTML is provided
+        elif raw_html_description_for_fallback:  # Check if fallback HTML is provided
             plain_html_text = strip_html_to_text(raw_html_description_for_fallback)
-            if plain_html_text and plain_html_text.strip(): # Check if not empty after stripping
+            if (
+                plain_html_text and plain_html_text.strip()
+            ):  # Check if not empty after stripping
                 description_content_for_embedding = plain_html_text.lower().strip()
         # (Implicit Priority 3: If damasco_product_data.get("description") was the old fallback)
         # The new logic in celery_tasks.py already passes the correct raw_html_incoming
         # so we don't need to look into damasco_product_data["description"] here for the fallback.
-        
+
         parts_to_join: List[str] = []
 
         # Helper to add parts if they are valid strings
@@ -152,38 +244,41 @@ class Product(Base):
                 cleaned = text.lower().strip()
                 if cleaned:
                     parts_to_join.append(cleaned)
-            elif text: # Attempt to convert other non-None types to string
+            elif text:  # Attempt to convert other non-None types to string
                 try:
                     cleaned = str(text).lower().strip()
                     if cleaned:
                         parts_to_join.append(cleaned)
                 except Exception:
-                    pass # Skip if conversion fails
+                    pass  # Skip if conversion fails
 
         add_part(damasco_product_data.get("brand"))
-        add_part(damasco_product_data.get("itemName")) # Item name is crucial
-        
-        if description_content_for_embedding: # Add only if it's not empty
+        add_part(damasco_product_data.get("itemName"))  # Item name is crucial
+
+        if description_content_for_embedding:  # Add only if it's not empty
             add_part(description_content_for_embedding)
-            
+
         add_part(damasco_product_data.get("category"))
         add_part(damasco_product_data.get("subCategory"))
         add_part(damasco_product_data.get("itemGroupName"))
         add_part(damasco_product_data.get("line"))
-        
+
         # Note: Numerical price fields like 'price' or 'priceBolivar' are generally NOT included
         # in the text for semantic embedding, as their exact values change frequently and
         # embeddings are more about the 'what' than precise, volatile numerical data.
         # The current logic correctly omits them.
 
         if not parts_to_join:
-            logger.warning(f"No text parts found to build embedding string for itemCode: {damasco_product_data.get('itemCode')}")
-            return None 
+            logger.warning(
+                f"No text parts found to build embedding string for itemCode: {damasco_product_data.get('itemCode')}"
+            )
+            return None
 
         final_text = " ".join(parts_to_join)
         # Normalize multiple spaces to single, and strip leading/trailing whitespace
-        final_text = re.sub(r'\s+', ' ', final_text).strip() 
-        
+        final_text = re.sub(r"\s+", " ", final_text).strip()
+
         return final_text if final_text else None
+
 
 # --- End of NAMWOO/models/product.py ---

--- a/namwoo_app/services/product_service.py
+++ b/namwoo_app/services/product_service.py
@@ -2,20 +2,21 @@
 
 import logging
 import re
-from typing import List, Dict, Any, Optional, Tuple, Union # Added Union
-from decimal import Decimal, ROUND_HALF_UP, InvalidOperation as InvalidDecimalOperation
-from datetime import datetime # Keep this if you use it, e.g., for updated_at
+from datetime import datetime  # Keep this if you use it, e.g., for updated_at
+from decimal import ROUND_HALF_UP, Decimal
+from decimal import InvalidOperation as InvalidDecimalOperation
+from typing import Any, Dict, List, Optional, Tuple, Union  # Added Union
 
 import numpy as np
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from ..models.product import Product # Product model used for ORM and Product.to_dict()
-from ..utils import db_utils, embedding_utils # embedding_utils for search
-from ..utils.string_utils import canonicalize_whs_name
-from ..config import Config # For Config.OPENAI_EMBEDDING_MODEL
+from ..config import Config  # For Config.OPENAI_EMBEDDING_MODEL
+from ..models.product import Product  # Product model used for ORM and Product.to_dict()
+from ..utils import db_utils, embedding_utils  # embedding_utils for search
+from ..utils.whs_utils import canonicalize_whs
 
-logger = logging.getLogger(__name__) # Standard logger for this module
+logger = logging.getLogger(__name__)  # Standard logger for this module
 
 # --- Semantic Helpers ---
 _ACCESSORY_PAT = re.compile(
@@ -29,24 +30,29 @@ _MAIN_TYPE_PAT = re.compile(
     flags=re.I,
 )
 
+
 def _is_accessory(name: str) -> bool:
-    if not name: return False
+    if not name:
+        return False
     return bool(_ACCESSORY_PAT.search(name))
 
+
 def _extract_main_type(text: str) -> str:
-    if not text: return ""
+    if not text:
+        return ""
     m = _MAIN_TYPE_PAT.search(text)
     return m.group(0).lower() if m else ""
+
 
 # --- Search Products ---
 def search_local_products(
     query_text: str,
     limit: int = 30,
     filter_stock: bool = True,
-    min_score: float = 0.01, # MODIFIED: Lowered min_score for diagnostics
+    min_score: float = 0.01,  # MODIFIED: Lowered min_score for diagnostics
     warehouse_names: Optional[List[str]] = None,
-    min_price: Optional[Union[float, int, str]] = None, 
-    max_price: Optional[Union[float, int, str]] = None  
+    min_price: Optional[Union[float, int, str]] = None,
+    max_price: Optional[Union[float, int, str]] = None,
 ) -> Optional[List[Dict[str, Any]]]:
     if not query_text or not isinstance(query_text, str):
         logger.warning("Search query is empty or invalid.")
@@ -56,10 +62,10 @@ def search_local_products(
         f"Vector search initiated: '{query_text[:80]}…'",
         f"limit={limit}",
         f"stock_filter={filter_stock}",
-        f"min_score={min_score:.2f}"
+        f"min_score={min_score:.2f}",
     ]
     if warehouse_names:
-        warehouse_names = [canonicalize_whs_name(w) for w in warehouse_names if w]
+        warehouse_names = [canonicalize_whs(w) for w in warehouse_names if w]
         log_message_parts.append(f"warehouses={warehouse_names}")
     if min_price is not None:
         log_message_parts.append(f"min_price={min_price}")
@@ -78,12 +84,18 @@ def search_local_products(
         max_price,
     )
 
-    embedding_model = Config.OPENAI_EMBEDDING_MODEL if hasattr(Config, 'OPENAI_EMBEDDING_MODEL') else "text-embedding-3-small"
+    embedding_model = (
+        Config.OPENAI_EMBEDDING_MODEL
+        if hasattr(Config, "OPENAI_EMBEDDING_MODEL")
+        else "text-embedding-3-small"
+    )
     query_emb = embedding_utils.get_embedding(query_text, model=embedding_model)
     if not query_emb:
         logger.error("Query embedding generation failed – aborting search.")
         return None
-    logger.debug("Generated embedding length: %d using model %s", len(query_emb), embedding_model)
+    logger.debug(
+        "Generated embedding length: %d using model %s", len(query_emb), embedding_model
+    )
 
     with db_utils.get_db_session() as session:
         if not session:
@@ -100,7 +112,7 @@ def search_local_products(
                 applied_filters.append("stock>0")
 
             if warehouse_names:
-                q = q.filter(Product.warehouse_name.in_(warehouse_names))
+                q = q.filter(Product.warehouse_name_canonical.in_(warehouse_names))
                 applied_filters.append(f"warehouses={warehouse_names}")
 
             # Removed: q = q.filter(Product.item_group_name == "DAMASCO TECNO") # Confirmed REMOVED
@@ -109,25 +121,35 @@ def search_local_products(
             min_price_decimal = None
             if min_price is not None:
                 try:
-                    min_price_decimal = Decimal(str(min_price)).quantize(Decimal('0.01'))
+                    min_price_decimal = Decimal(str(min_price)).quantize(
+                        Decimal("0.01")
+                    )
                     q = q.filter(Product.price >= min_price_decimal)
                     applied_filters.append(f"price>={min_price_decimal}")
                     logger.info(f"Applying min_price filter: >= {min_price_decimal}")
                 except InvalidDecimalOperation:
-                    logger.warning(f"Invalid min_price value '{min_price}' provided. Ignoring min_price filter.")
+                    logger.warning(
+                        f"Invalid min_price value '{min_price}' provided. Ignoring min_price filter."
+                    )
 
             max_price_decimal = None
             if max_price is not None:
                 try:
-                    max_price_decimal = Decimal(str(max_price)).quantize(Decimal('0.01'))
+                    max_price_decimal = Decimal(str(max_price)).quantize(
+                        Decimal("0.01")
+                    )
                     q = q.filter(Product.price <= max_price_decimal)
                     applied_filters.append(f"price<={max_price_decimal}")
                     logger.info(f"Applying max_price filter: <= {max_price_decimal}")
                 except InvalidDecimalOperation:
-                    logger.warning(f"Invalid max_price value '{max_price}' provided. Ignoring max_price filter.")
+                    logger.warning(
+                        f"Invalid max_price value '{max_price}' provided. Ignoring max_price filter."
+                    )
 
             # Diagnostic: log similarity scores before applying min_score
-            diagnostic_q = q.order_by(Product.embedding.cosine_distance(query_emb)).limit(limit)
+            diagnostic_q = q.order_by(
+                Product.embedding.cosine_distance(query_emb)
+            ).limit(limit)
             diagnostic_rows: List[Tuple[Product, float]] = diagnostic_q.all()
             logger.debug("Applied filters for diagnostic query: %s", applied_filters)
             logger.debug(
@@ -149,7 +171,9 @@ def search_local_products(
             if filter_stock:
                 q_final = q_final.filter(Product.stock > 0)
             if warehouse_names:
-                q_final = q_final.filter(Product.warehouse_name.in_(warehouse_names))
+                q_final = q_final.filter(
+                    Product.warehouse_name_canonical.in_(warehouse_names)
+                )
             if min_price_decimal is not None:
                 q_final = q_final.filter(Product.price >= min_price_decimal)
             if max_price_decimal is not None:
@@ -157,19 +181,27 @@ def search_local_products(
             q_final = q_final.filter(
                 (1 - Product.embedding.cosine_distance(query_emb)) >= min_score
             )
-            q_final = q_final.order_by(Product.embedding.cosine_distance(query_emb)).limit(limit)
+            q_final = q_final.order_by(
+                Product.embedding.cosine_distance(query_emb)
+            ).limit(limit)
 
             rows: List[Tuple[Product, float]] = q_final.all()
             logger.debug("DB returned %d rows after final filters", len(rows))
             results: List[Dict[str, Any]] = []
             for prod_location_entry, sim_score in rows:
                 item_dict = prod_location_entry.to_dict()
-                item_dict.update({
-                    "similarity": round(float(sim_score), 4),
-                    "is_accessory": _is_accessory(prod_location_entry.item_name or ""),
-                    "main_type": _extract_main_type(prod_location_entry.item_name or ""),
-                    "llm_formatted_description": prod_location_entry.format_for_llm() 
-                })
+                item_dict.update(
+                    {
+                        "similarity": round(float(sim_score), 4),
+                        "is_accessory": _is_accessory(
+                            prod_location_entry.item_name or ""
+                        ),
+                        "main_type": _extract_main_type(
+                            prod_location_entry.item_name or ""
+                        ),
+                        "llm_formatted_description": prod_location_entry.format_for_llm(),
+                    }
+                )
                 results.append(item_dict)
             if not results and filter_stock:
                 logger.info(
@@ -200,43 +232,41 @@ def search_local_products(
             logger.exception("Unexpected error during product search: %s", exc)
             return None
 
+
 def _normalize_string(value: Any) -> Optional[str]:
     if value is None:
         return None
     s = str(value).strip()
     return s if s else None
 
-def get_product_by_id_from_db(db_session: Session, product_id: str) -> Optional[Product]:
+
+def get_product_by_id_from_db(
+    db_session: Session, product_id: str
+) -> Optional[Product]:
     """Helper to fetch a product by its composite ID."""
     if not product_id:
         return None
     return db_session.query(Product).filter(Product.id == product_id).first()
 
+
 def add_or_update_product_in_db(
     session: Session,
-    damasco_product_data_camel: Dict[str, Any], # Main data bundle (camelCase keys)
-    embedding_vector: Optional[Any], # List[float], np.ndarray, or None
+    damasco_product_data_camel: Dict[str, Any],  # Main data bundle (camelCase keys)
+    embedding_vector: Optional[Any],  # List[float], np.ndarray, or None
     text_used_for_embedding: Optional[str],
-    llm_summarized_description_to_store: Optional[str]
+    llm_summarized_description_to_store: Optional[str],
 ) -> Tuple[bool, str]:
-    
+
     item_code = _normalize_string(damasco_product_data_camel.get("itemCode"))
     whs_name_raw = _normalize_string(damasco_product_data_camel.get("whsName"))
-    whs_name = canonicalize_whs_name(whs_name_raw)
+    if not item_code or not whs_name_raw:
+        logger.error("Missing itemCode or whsName; cannot upsert product.")
+        return False, "missing_item_or_whs"
+    whs_canonical = canonicalize_whs(whs_name_raw)
 
-    _temp_product_id_for_upsert: Optional[str] = None
-    if item_code and whs_name:
-        sanitized_whs_name = re.sub(r'[^A-Z0-9_-]', '_', whs_name)
-        _temp_product_id_for_upsert = f"{item_code}_{sanitized_whs_name}"
-        if len(_temp_product_id_for_upsert) > 512:
-            _temp_product_id_for_upsert = _temp_product_id_for_upsert[:512]
-    
-    product_id_to_upsert = _temp_product_id_for_upsert
-
-    if not product_id_to_upsert:
-        logger.error("Could not derive product_id_to_upsert from itemCode/whsName in damasco_product_data_camel.")
-        return False, "Missing product_id_to_upsert (could not derive)."
-    if not damasco_product_data_camel or not isinstance(damasco_product_data_camel, dict):
+    if not damasco_product_data_camel or not isinstance(
+        damasco_product_data_camel, dict
+    ):
         return False, "Missing or invalid Damasco product data (camelCase)."
 
     embedding_vector_for_db: Optional[List[float]] = None
@@ -246,49 +276,76 @@ def add_or_update_product_in_db(
         elif isinstance(embedding_vector, list):
             embedding_vector_for_db = embedding_vector
         else:
-            logger.error(f"Product ID {product_id_to_upsert}: Unexpected embedding vector type ({type(embedding_vector)}).")
-            return False, f"Invalid embedding vector type for {product_id_to_upsert} (must be list or numpy.ndarray)."
+            logger.error(
+                f"Product upsert {item_code}@{whs_canonical}: Unexpected embedding vector type ({type(embedding_vector)})."
+            )
+            return False, "invalid_embedding_type"
 
-        expected_dim = Config.EMBEDDING_DIMENSION if hasattr(Config, 'EMBEDDING_DIMENSION') and Config.EMBEDDING_DIMENSION else None
-        if expected_dim and embedding_vector_for_db and len(embedding_vector_for_db) != expected_dim: 
-            return False, (f"Embedding dimension mismatch for {product_id_to_upsert} (expected {expected_dim}, "
-                           f"got {len(embedding_vector_for_db)}).")
+        expected_dim = (
+            Config.EMBEDDING_DIMENSION
+            if hasattr(Config, "EMBEDDING_DIMENSION") and Config.EMBEDDING_DIMENSION
+            else None
+        )
+        if (
+            expected_dim
+            and embedding_vector_for_db
+            and len(embedding_vector_for_db) != expected_dim
+        ):
+            return False, (
+                f"Embedding dimension mismatch for {item_code}@{whs_canonical} (expected {expected_dim}, got {len(embedding_vector_for_db)})."
+            )
 
-    if embedding_vector_for_db is not None and (not text_used_for_embedding or not isinstance(text_used_for_embedding, str)):
-        logger.warning(f"Product ID {product_id_to_upsert}: Embedding vector present, but text_used_for_embedding is missing or invalid.")
+    if embedding_vector_for_db is not None and (
+        not text_used_for_embedding or not isinstance(text_used_for_embedding, str)
+    ):
+        logger.warning(
+            f"Product {item_code}@{whs_canonical}: Embedding vector present, but text_used_for_embedding is missing or invalid."
+        )
 
-    log_prefix = f"ProductService DB Upsert (ID='{product_id_to_upsert}'):"
+    log_prefix = f"ProductService DB Upsert ({item_code}@{whs_canonical}):"
 
     raw_html_description_to_store = damasco_product_data_camel.get("description")
     item_name = _normalize_string(damasco_product_data_camel.get("itemName"))
-    
-    price_from_damasco = damasco_product_data_camel.get("price") 
+
+    price_from_damasco = damasco_product_data_camel.get("price")
     normalized_price_for_db: Optional[Decimal] = None
     if price_from_damasco is not None:
         try:
-            normalized_price_for_db = Decimal(str(price_from_damasco)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            normalized_price_for_db = Decimal(str(price_from_damasco)).quantize(
+                Decimal("0.01"), rounding=ROUND_HALF_UP
+            )
         except InvalidDecimalOperation:
-            logger.warning(f"{log_prefix} Invalid price value '{price_from_damasco}' for USD price, treating as None.")
+            logger.warning(
+                f"{log_prefix} Invalid price value '{price_from_damasco}' for USD price, treating as None."
+            )
 
-    price_bolivar_from_damasco = damasco_product_data_camel.get("priceBolivar") 
+    price_bolivar_from_damasco = damasco_product_data_camel.get("priceBolivar")
     normalized_price_bolivar_for_db: Optional[Decimal] = None
     if price_bolivar_from_damasco is not None:
         try:
-            normalized_price_bolivar_for_db = Decimal(str(price_bolivar_from_damasco)).quantize(Decimal('0.01'), rounding=ROUND_HALF_UP)
+            normalized_price_bolivar_for_db = Decimal(
+                str(price_bolivar_from_damasco)
+            ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
         except InvalidDecimalOperation:
-            logger.warning(f"{log_prefix} Invalid priceBolivar value '{price_bolivar_from_damasco}', treating as None.")
+            logger.warning(
+                f"{log_prefix} Invalid priceBolivar value '{price_bolivar_from_damasco}', treating as None."
+            )
 
     stock_from_damasco = damasco_product_data_camel.get("stock")
     normalized_stock_for_db = 0
     if stock_from_damasco is not None:
         try:
-            normalized_stock_for_db = int(stock_from_damasco) 
+            normalized_stock_for_db = int(stock_from_damasco)
             if normalized_stock_for_db < 0:
-                logger.warning(f"{log_prefix} Negative stock value '{stock_from_damasco}' received, setting to 0.")
+                logger.warning(
+                    f"{log_prefix} Negative stock value '{stock_from_damasco}' received, setting to 0."
+                )
                 normalized_stock_for_db = 0
         except (ValueError, TypeError):
-            logger.warning(f"{log_prefix} Invalid stock value '{stock_from_damasco}', defaulting to 0.")
-    
+            logger.warning(
+                f"{log_prefix} Invalid stock value '{stock_from_damasco}', defaulting to 0."
+            )
+
     norm_raw_html = _normalize_string(raw_html_description_to_store)
     norm_llm_summary = _normalize_string(llm_summarized_description_to_store)
     norm_searchable_text = _normalize_string(text_used_for_embedding)
@@ -299,84 +356,134 @@ def add_or_update_product_in_db(
         "description": norm_raw_html,
         "llm_summarized_description": norm_llm_summary,
         "category": _normalize_string(damasco_product_data_camel.get("category")),
-        "sub_category": _normalize_string(damasco_product_data_camel.get("subCategory")),
+        "sub_category": _normalize_string(
+            damasco_product_data_camel.get("subCategory")
+        ),
         "brand": _normalize_string(damasco_product_data_camel.get("brand")),
         "line": _normalize_string(damasco_product_data_camel.get("line")),
-        "item_group_name": _normalize_string(damasco_product_data_camel.get("itemGroupName")),
-        "warehouse_name": whs_name, 
+        "item_group_name": _normalize_string(
+            damasco_product_data_camel.get("itemGroupName")
+        ),
+        "warehouse_name": whs_name_raw,
         "branch_name": _normalize_string(damasco_product_data_camel.get("branchName")),
-        "price": normalized_price_for_db, 
-        "price_bolivar": normalized_price_bolivar_for_db, 
-        "stock": normalized_stock_for_db, 
+        "price": normalized_price_for_db,
+        "price_bolivar": normalized_price_bolivar_for_db,
+        "stock": normalized_stock_for_db,
         "searchable_text_content": norm_searchable_text,
-        "embedding": embedding_vector_for_db, 
-        "source_data_json": damasco_product_data_camel 
+        "embedding": embedding_vector_for_db,
+        "source_data_json": damasco_product_data_camel,
     }
 
     try:
-        entry = get_product_by_id_from_db(session, product_id_to_upsert)
+        entry = (
+            session.query(Product)
+            .filter_by(
+                item_code=item_code,
+                warehouse_name_canonical=whs_canonical,
+            )
+            .first()
+        )
 
-        if entry: 
+        if entry:
             changed_fields_log_details = []
             needs_update = False
 
             for field_key, new_value in new_values_map.items():
-                if field_key == "source_data_json": 
-                    if entry.source_data_json != new_value: 
+                if field_key == "source_data_json":
+                    if entry.source_data_json != new_value:
                         needs_update = True
-                        changed_fields_log_details.append(f"{field_key}: (JSON content changed)")
-                    continue 
+                        changed_fields_log_details.append(
+                            f"{field_key}: (JSON content changed)"
+                        )
+                    continue
 
                 db_value = getattr(entry, field_key, None)
                 is_different = False
 
                 if field_key == "embedding":
-                    db_value_list = db_value.tolist() if isinstance(db_value, np.ndarray) else db_value
-                    new_value_list = new_value 
-                    if (db_value_list is None and new_value_list is not None) or \
-                       (db_value_list is not None and new_value_list is None) or \
-                       (db_value_list is not None and new_value_list is not None and not np.array_equal(np.array(db_value_list, dtype=float), np.array(new_value_list, dtype=float))):
+                    db_value_list = (
+                        db_value.tolist()
+                        if isinstance(db_value, np.ndarray)
+                        else db_value
+                    )
+                    new_value_list = new_value
+                    if (
+                        (db_value_list is None and new_value_list is not None)
+                        or (db_value_list is not None and new_value_list is None)
+                        or (
+                            db_value_list is not None
+                            and new_value_list is not None
+                            and not np.array_equal(
+                                np.array(db_value_list, dtype=float),
+                                np.array(new_value_list, dtype=float),
+                            )
+                        )
+                    ):
                         is_different = True
-                elif field_key in ["price", "price_bolivar"]: 
-                    if (db_value is None and new_value is not None) or \
-                       (db_value is not None and new_value is None) or \
-                       (db_value is not None and new_value is not None and db_value != new_value): 
+                elif field_key in ["price", "price_bolivar"]:
+                    if (
+                        (db_value is None and new_value is not None)
+                        or (db_value is not None and new_value is None)
+                        or (
+                            db_value is not None
+                            and new_value is not None
+                            and db_value != new_value
+                        )
+                    ):
                         is_different = True
-                else: 
+                else:
                     if db_value != new_value:
                         is_different = True
-                
+
                 if is_different:
                     needs_update = True
-                    log_new_val = str(new_value)[:70] + "..." if isinstance(new_value, (str, list, np.ndarray, dict)) and len(str(new_value)) > 70 else new_value
-                    log_db_val = str(db_value)[:70] + "..." if isinstance(db_value, (str, list, np.ndarray, dict)) and len(str(db_value)) > 70 else db_value
-                    if field_key == "embedding" and new_value is not None: log_new_val = f"Vector(len={len(new_value)})"
-                    if field_key == "embedding" and db_value is not None: log_db_val = f"Vector(len={len(db_value) if isinstance(db_value, list) else ('np.array' if isinstance(db_value, np.ndarray) else 'UnknownType')})"
-                    changed_fields_log_details.append(f"{field_key}: (DB='{log_db_val}' -> New='{log_new_val}')")
+                    log_new_val = (
+                        str(new_value)[:70] + "..."
+                        if isinstance(new_value, (str, list, np.ndarray, dict))
+                        and len(str(new_value)) > 70
+                        else new_value
+                    )
+                    log_db_val = (
+                        str(db_value)[:70] + "..."
+                        if isinstance(db_value, (str, list, np.ndarray, dict))
+                        and len(str(db_value)) > 70
+                        else db_value
+                    )
+                    if field_key == "embedding" and new_value is not None:
+                        log_new_val = f"Vector(len={len(new_value)})"
+                    if field_key == "embedding" and db_value is not None:
+                        log_db_val = f"Vector(len={len(db_value) if isinstance(db_value, list) else ('np.array' if isinstance(db_value, np.ndarray) else 'UnknownType')})"
+                    changed_fields_log_details.append(
+                        f"{field_key}: (DB='{log_db_val}' -> New='{log_new_val}')"
+                    )
 
             if not needs_update:
                 logger.info(f"{log_prefix} No changes detected. Skipping DB write.")
                 return True, "skipped_no_change"
-            
-            logger.info(f"{log_prefix} Changes detected. Updating entry. Details: {'; '.join(changed_fields_log_details)}")
+
+            logger.info(
+                f"{log_prefix} Changes detected. Updating entry. Details: {'; '.join(changed_fields_log_details)}"
+            )
             for key, value in new_values_map.items():
                 setattr(entry, key, value)
-            entry.updated_at = datetime.utcnow() 
-            
+            entry.updated_at = datetime.utcnow()
+
             session.commit()
             logger.info(f"{log_prefix} Entry successfully updated.")
             op_msg = "updated"
-            if changed_fields_log_details: 
-                op_msg = f"updated (Changes: {', '.join(changed_fields_log_details[:3])}"
-                if len(changed_fields_log_details) > 3: op_msg += " ...)" 
-                else: op_msg += ")"
+            if changed_fields_log_details:
+                op_msg = (
+                    f"updated (Changes: {', '.join(changed_fields_log_details[:3])}"
+                )
+                if len(changed_fields_log_details) > 3:
+                    op_msg += " ...)"
+                else:
+                    op_msg += ")"
             return True, op_msg
 
-        else: 
+        else:
             logger.info(f"{log_prefix} New product. Adding to DB.")
-            new_product_kwargs = {"id": product_id_to_upsert} 
-            new_product_kwargs.update(new_values_map) 
-            entry = Product(**new_product_kwargs)
+            entry = Product(**new_values_map)
             session.add(entry)
             session.commit()
             logger.info(f"{log_prefix} New entry successfully added.")
@@ -384,43 +491,63 @@ def add_or_update_product_in_db(
 
     except SQLAlchemyError as db_exc:
         session.rollback()
-        logger.error(f"{log_prefix} DB error during add/update: {db_exc}", exc_info=True)
+        logger.error(
+            f"{log_prefix} DB error during add/update: {db_exc}", exc_info=True
+        )
         err_str = str(db_exc).lower()
         if "violates unique constraint" in err_str:
-             return False, f"db_constraint_violation: {str(db_exc)[:200]}" 
+            return False, f"db_constraint_violation: {str(db_exc)[:200]}"
         return False, f"db_sqlalchemy_error: {str(db_exc)[:200]}"
-    except Exception as exc: 
+    except Exception as exc:
         session.rollback()
         logger.exception(f"{log_prefix} Unexpected error processing: {exc}")
         return False, f"db_unexpected_error: {str(exc)[:200]}"
 
+
 # --- Getter functions ---
-def get_live_product_details_by_sku(item_code_query: str) -> Optional[List[Dict[str, Any]]]:
+def get_live_product_details_by_sku(
+    item_code_query: str,
+) -> Optional[List[Dict[str, Any]]]:
     if not item_code_query:
-        logger.error("get_live_product_details_by_sku: Missing item_code_query argument.")
-        return None 
+        logger.error(
+            "get_live_product_details_by_sku: Missing item_code_query argument."
+        )
+        return None
     normalized_item_code = _normalize_string(item_code_query)
     if not normalized_item_code:
-        logger.warning(f"get_live_product_details_by_sku: item_code_query '{item_code_query}' normalized to empty/None.")
-        return [] 
+        logger.warning(
+            f"get_live_product_details_by_sku: item_code_query '{item_code_query}' normalized to empty/None."
+        )
+        return []
     with db_utils.get_db_session() as session:
-        if not session: 
+        if not session:
             logger.error("DB session unavailable for get_live_product_details_by_sku.")
             return None
         try:
-            product_entries = session.query(Product).filter_by(item_code=normalized_item_code).all()
+            product_entries = (
+                session.query(Product).filter_by(item_code=normalized_item_code).all()
+            )
             if not product_entries:
-                logger.info(f"No product entries found with item_code: {normalized_item_code}")
-                return [] 
-            results = [entry.to_dict() for entry in product_entries] 
-            logger.info(f"Found {len(results)} locations for item_code: {normalized_item_code}")
+                logger.info(
+                    f"No product entries found with item_code: {normalized_item_code}"
+                )
+                return []
+            results = [entry.to_dict() for entry in product_entries]
+            logger.info(
+                f"Found {len(results)} locations for item_code: {normalized_item_code}"
+            )
             return results
         except SQLAlchemyError as db_exc:
-            logger.exception(f"DB error fetching product by item_code: {normalized_item_code}, Error: {db_exc}")
-            return None 
-        except Exception as exc: 
-            logger.exception(f"Unexpected error fetching product by item_code: {normalized_item_code}, Error: {exc}")
+            logger.exception(
+                f"DB error fetching product by item_code: {normalized_item_code}, Error: {db_exc}"
+            )
             return None
+        except Exception as exc:
+            logger.exception(
+                f"Unexpected error fetching product by item_code: {normalized_item_code}, Error: {exc}"
+            )
+            return None
+
 
 def get_live_product_details_by_id(composite_id: str) -> Optional[Dict[str, Any]]:
     if not composite_id:
@@ -437,8 +564,12 @@ def get_live_product_details_by_id(composite_id: str) -> Optional[Dict[str, Any]
                 return None
             return product_entry.to_dict()
         except SQLAlchemyError as db_exc:
-            logger.exception(f"DB error fetching product by composite_id: {composite_id}, Error: {db_exc}")
+            logger.exception(
+                f"DB error fetching product by composite_id: {composite_id}, Error: {db_exc}"
+            )
             return None
         except Exception as exc:
-            logger.exception(f"Unexpected error fetching product by composite_id: {composite_id}, Error: {exc}")
+            logger.exception(
+                f"Unexpected error fetching product by composite_id: {composite_id}, Error: {exc}"
+            )
             return None

--- a/namwoo_app/utils/whs_utils.py
+++ b/namwoo_app/utils/whs_utils.py
@@ -1,0 +1,11 @@
+import re
+import unicodedata
+
+
+def canonicalize_whs(raw: str) -> str:
+    """Return canonical warehouse name as ID-friendly string."""
+    if raw is None:
+        return ""
+    s = unicodedata.normalize("NFKD", raw).encode("ascii", "ignore").decode()
+    s = re.sub(r"[^A-Za-z0-9]+", "_", s).upper().strip("_")
+    return s

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -1,0 +1,67 @@
+import importlib.util
+import os
+
+import pytest
+
+UTILS_PATH = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "namwoo_app", "utils", "whs_utils.py")
+)
+spec = importlib.util.spec_from_file_location("whs_utils", UTILS_PATH)
+whs_utils = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(whs_utils)
+canonicalize_whs = whs_utils.canonicalize_whs
+
+
+class IntegrityError(Exception):
+    pass
+
+
+class FakeSession:
+    def __init__(self):
+        self._data = {}
+
+    def add(self, product):
+        key = (product["item_code"], product["warehouse_name_canonical"])
+        if key in self._data:
+            raise IntegrityError("duplicate key")
+        self._data[key] = product
+
+    def commit(self):
+        pass
+
+    def search(self, warehouse_names):
+        canon = [canonicalize_whs(w) for w in warehouse_names]
+        return [
+            p for p in self._data.values() if p["warehouse_name_canonical"] in canon
+        ]
+
+
+@pytest.fixture
+def session():
+    return FakeSession()
+
+
+def add_prod(sess, item_code, whs_name, **extra):
+    prod = {
+        "item_code": item_code,
+        "warehouse_name": whs_name,
+        "warehouse_name_canonical": canonicalize_whs(whs_name),
+        "item_name": extra.get("item_name", "Foo"),
+        "category": extra.get("category", "BAR"),
+        "price": extra.get("price", 1),
+        "stock": extra.get("stock", 0),
+    }
+    sess.add(prod)
+    sess.commit()
+
+
+def test_canonical_sku_uniqueness(session):
+    add_prod(session, "TEST123", "Almacén Principal Sabana Grande")
+    with pytest.raises(IntegrityError):
+        add_prod(session, "TEST123", "ALMACEN PRINCIPAL SABANA_GRANDE")
+
+
+def test_search_accent_insensitive(session):
+    add_prod(session, "SKU1", "Sabana Grande", item_name="licuadora X")
+    res = session.search(["Sabána Grande"])
+    assert res, "Should find rows regardless of accent / case"


### PR DESCRIPTION
## Summary
- add helper for canonical warehouse names
- track canonical name in Product ORM model
- search using the canonical column
- update product upsert logic for canonical handling
- test canonical warehouse search and uniqueness

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a35e6632c832bb32a71e6ef947a34