### PR TITLE
Add color variant lookup and improve WhatsApp template API

### DIFF
--- a/namwoo_app/utils/product_utils.py
+++ b/namwoo_app/utils/product_utils.py
@@ -2,26 +2,45 @@
 import re
 from typing import Optional, Any
 
+
 def _normalize_string_for_id_part(value: Any) -> Optional[str]:
-    if value is None: return None
+    if value is None:
+        return None
     s = str(value).strip()
     return s if s else None
 
+
 def generate_product_location_id(item_code_raw: Any, whs_name_raw: Any) -> Optional[str]:
-    """
-    Generates the composite product ID consistently.
-    Returns None if essential parts (item_code, whs_name) are missing after normalization.
-    """
+    """Generates the composite product ID consistently."""
     item_code = _normalize_string_for_id_part(item_code_raw)
     whs_name = _normalize_string_for_id_part(whs_name_raw)
-
     if not item_code or not whs_name:
-        # logger.warning("Cannot generate product_location_id: item_code or whs_name is missing/empty after normalization.")
-        return None 
-
+        return None
     sanitized_whs_name = re.sub(r'[^a-zA-Z0-9_-]', '_', whs_name)
     product_id = f"{item_code}_{sanitized_whs_name}"
-    if len(product_id) > 512: # Max length of Product.id
-        # logger.warning(f"Generated product_location_id for {item_code} was truncated to 512 chars.")
+    if len(product_id) > 512:
         product_id = product_id[:512]
     return product_id
+
+
+# --- New helper functions for color detection ---
+_COLOR_PATTERNS = {
+    "ROJO": ["ROJO", "RED"],
+    "AZUL": ["AZUL", "BLUE"],
+    "NEGRO": ["NEGRO", "BLACK"],
+    "BLANCO": ["BLANCO", "WHITE"],
+    "VERDE": ["VERDE", "GREEN"],
+    "GRIS": ["GRIS", "GRAY", "GREY"],
+}
+
+
+def strip_color_suffix(item_code: str) -> str:
+    """Return item_code without any recognised color suffix."""
+    if not item_code:
+        return ""
+    code = item_code.upper()
+    for canonical, variants in _COLOR_PATTERNS.items():
+        for var in variants:
+            if code.endswith(f"-{var}") or code.endswith(f"_{var}"):
+                return code[: -len(var) - 1]
+    return code


### PR DESCRIPTION
## Summary
- implement helper to strip color suffixes and add color variant lookup
- expose new `get_color_variants` tool to the LLM
- send WhatsApp templates via JSON API request
- support color variant logic in product service
- adjust WhatsApp template test for new API call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a6b92fcd4832b84ab7898e69b8b4b