### PR TITLE
Support especificacion field in models and pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ The system relies on an external **Fetcher Service** to acquire product data fro
         *   This crucial step constructs the `searchable_text_content`.
         *   It **prioritizes the `llm_generated_summary`**. If a summary is available, it's used as the primary descriptive component.
         *   If no LLM summary is available, it falls back to using the plain text obtained by stripping the raw HTML description.
-        *   This processed description is then concatenated with other key product attributes (brand, name, category, etc.) to form the final `text_to_embed`.
+        *   This processed description is then concatenated with other key product attributes (brand, name, category, **especificacion**, etc.) to form the final `text_to_embed`.
     5.  **Vector Embedding Generation (`openai_service.generate_product_embedding()`):**
         *   The `text_to_embed` is converted into a high-dimensional numerical vector (embedding).
     6.  **Database Upsert with Delta Detection (`product_service.add_or_update_product_in_db()`):**
         *   Efficiently updates PostgreSQL, comparing new processed values against existing records.
         *   **If no significant changes are detected**, the database write operation is skipped.
-        *   If changes are found, or if the item is new, relevant fields including `description` (raw HTML), `llm_summarized_description`, `searchable_text_content`, and `embedding_vector` are stored/updated.
+        *   If changes are found, or if the item is new, relevant fields including `description` (raw HTML), `especificacion`, `llm_summarized_description`, `searchable_text_content`, and `embedding_vector` are stored/updated.
         *   The original `damasco_product_data` is stored in `source_data_json` for auditing.
 
 ### 2. Semantic Product Search via Vector Embeddings
@@ -149,7 +149,7 @@ A key aspect is distinguishing messages from different sources to ensure correct
 | | |-- store_locations.json # NEW: Stores location data for the `get_store_info` tool
 | |-- models/
 | | |-- init.py # Defines SQLAlchemy Base, imports all models
-| | |-- product.py # Product ORM model (with description, llm_summarized_description)
+| | |-- product.py # Product ORM model (with description, especificacion, llm_summarized_description)
 | | |-- conversation_pause.py # ConversationPause ORM model
 | |-- services/
 | | |-- init.py # Exposes service functions/modules for easy import
@@ -171,7 +171,7 @@ A key aspect is distinguishing messages from different sources to ensure correct
 | |-- init.py
 | |-- tasks.py
 |-- data/ # Project-level data (e.g., SQL schema if not using migrations)
-| |-- schema.sql # Must include 'description', 'llm_summarized_description', and 'conversation_pauses' table
+| |-- schema.sql # Must include 'description', 'especificacion', 'llm_summarized_description', and 'conversation_pauses' table
 |-- logs/ # Created at runtime for log files
 |-- venv/ # Python virtual environment (.gitignored)
 |-- .env # Environment variables (SECRET! .gitignored)
@@ -199,7 +199,7 @@ A key aspect is distinguishing messages from different sources to ensure correct
     *   Support Platform (e.g., Nulu AI) installation/account with API token.
     *   LLM Provider API Key (OpenAI API Key and/or Google AI API Key for Gemini).
     *   `DAMASCO_API_SECRET`: A secret key to authenticate requests from your Fetcher Service.
-*   📡 **External Fetcher Service:** Must be set up to fetch raw HTML product descriptions and send them to NamDamasco's `/api/receive-products` endpoint.
+*   📡 **External Fetcher Service:** Must be set up to fetch raw HTML product descriptions and specification details, sending them to NamDamasco's `/api/receive-products` endpoint.
 *   🤖 **External Comment Bot (Optional but relevant for full setup):** If using, ensure it sends DMs via the Instagram Page. No direct code changes needed in the Comment Bot itself if relying on proxy ID, unless implementing `COMMENT_BOT_INITIATION_TAG`.
 *   📄 **Store Locations File:** Ensure `namwoo_app/data/store_locations.json` is created and populated with your store details.
 

--- a/namwoo_app/README.md
+++ b/namwoo_app/README.md
@@ -43,13 +43,13 @@ The system relies on an external **Fetcher Service** to acquire product data fro
         *   This crucial step constructs the `searchable_text_content`.
         *   It **prioritizes the `llm_generated_summary`**. If a summary is available, it's used as the primary descriptive component.
         *   If no LLM summary is available, it falls back to using the plain text obtained by stripping the raw HTML description.
-        *   This processed description is then concatenated with other key product attributes (brand, name, category, etc.) to form the final `text_to_embed`.
+        *   This processed description is then concatenated with other key product attributes (brand, name, category, **especificacion**, etc.) to form the final `text_to_embed`.
     5.  **Vector Embedding Generation (`openai_service.generate_product_embedding()`):**
         *   The `text_to_embed` is converted into a high-dimensional numerical vector (embedding).
     6.  **Database Upsert with Delta Detection (`product_service.add_or_update_product_in_db()`):**
         *   Efficiently updates PostgreSQL, comparing new processed values against existing records.
         *   **If no significant changes are detected**, the database write operation is skipped.
-        *   If changes are found, or if the item is new, relevant fields including `description` (raw HTML), `llm_summarized_description`, `searchable_text_content`, and `embedding_vector` are stored/updated.
+        *   If changes are found, or if the item is new, relevant fields including `description` (raw HTML), `especificacion`, `llm_summarized_description`, `searchable_text_content`, and `embedding_vector` are stored/updated.
         *   The original `damasco_product_data` is stored in `source_data_json` for auditing.
 
 ### 2. Semantic Product Search via Vector Embeddings
@@ -149,7 +149,7 @@ A key aspect is distinguishing messages from different sources to ensure correct
 | | |-- store_locations.json # NEW: Stores location data for the `get_store_info` tool
 | |-- models/
 | | |-- init.py # Defines SQLAlchemy Base, imports all models
-| | |-- product.py # Product ORM model (with description, llm_summarized_description)
+| | |-- product.py # Product ORM model (with description, especificacion, llm_summarized_description)
 | | |-- conversation_pause.py # ConversationPause ORM model
 | |-- services/
 | | |-- init.py # Exposes service functions/modules for easy import
@@ -171,7 +171,7 @@ A key aspect is distinguishing messages from different sources to ensure correct
 | |-- init.py
 | |-- tasks.py
 |-- data/ # Project-level data (e.g., SQL schema if not using migrations)
-| |-- schema.sql # Must include 'description', 'llm_summarized_description', and 'conversation_pauses' table
+| |-- schema.sql # Must include 'description', 'especificacion', 'llm_summarized_description', and 'conversation_pauses' table
 |-- logs/ # Created at runtime for log files
 |-- venv/ # Python virtual environment (.gitignored)
 |-- .env # Environment variables (SECRET! .gitignored)
@@ -199,7 +199,7 @@ A key aspect is distinguishing messages from different sources to ensure correct
     *   Support Platform (e.g., Nulu AI) installation/account with API token.
     *   LLM Provider API Key (OpenAI API Key and/or Google AI API Key for Gemini).
     *   `DAMASCO_API_SECRET`: A secret key to authenticate requests from your Fetcher Service.
-*   📡 **External Fetcher Service:** Must be set up to fetch raw HTML product descriptions and send them to NamDamasco's `/api/receive-products` endpoint.
+*   📡 **External Fetcher Service:** Must be set up to fetch raw HTML product descriptions and specification details, sending them to NamDamasco's `/api/receive-products` endpoint.
 *   🤖 **External Comment Bot (Optional but relevant for full setup):** If using, ensure it sends DMs via the Instagram Page. No direct code changes needed in the Comment Bot itself if relying on proxy ID, unless implementing `COMMENT_BOT_INITIATION_TAG`.
 *   📄 **Store Locations File:** Ensure `namwoo_app/data/store_locations.json` is created and populated with your store details.
 

--- a/namwoo_app/celery_tasks.py
+++ b/namwoo_app/celery_tasks.py
@@ -30,6 +30,7 @@ class DamascoProductDataSnake(BaseModel):
     stock: int
     price: Optional[Decimal] = None # Will be Decimal after validation
     price_bolivar: Optional[Decimal] = None # <<< NEW FIELD: Will be Decimal after validation
+    especificacion: Optional[str] = None  # New field for detailed specs
     category: Optional[str] = None
     sub_category: Optional[str] = None
     brand: Optional[str] = None
@@ -78,6 +79,7 @@ def _convert_snake_to_camel_case(data_snake: Dict[str, Any]) -> Dict[str, Any]:
         "brand": "brand",
         "line": "line",
         "item_group_name": "itemGroupName",
+        "especificacion": "especificacion",
         "warehouse_name": "whsName", # Pydantic model has 'warehouse_name'
         "branch_name": "branchName",
     }
@@ -202,7 +204,8 @@ def process_product_item_task(self, product_data_dict_snake: Dict[str, Any]):
         with db_utils.get_db_session() as read_session:
             try:
                 existing_product_db_entry = read_session.query(
-                    Product.description, 
+                    Product.description,
+                    Product.especificacion,
                     Product.llm_summarized_description,
                     Product.searchable_text_content,
                     Product.embedding
@@ -211,6 +214,7 @@ def process_product_item_task(self, product_data_dict_snake: Dict[str, Any]):
                 if existing_product_db_entry:
                     existing_product_details = {
                         "description": existing_product_db_entry.description,
+                        "especificacion": existing_product_db_entry.especificacion,
                         "llm_summarized_description": existing_product_db_entry.llm_summarized_description,
                         "searchable_text_content": existing_product_db_entry.searchable_text_content,
                         "embedding": existing_product_db_entry.embedding 

--- a/namwoo_app/data/schema.sql
+++ b/namwoo_app/data/schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE products (
     brand VARCHAR(128),                  -- Brand of the product
     line VARCHAR(128),                   -- Product line (from Damasco)
     item_group_name VARCHAR(128),        -- Broader group name (from Damasco)
+    especificacion TEXT,
 
     -- Location-specific attributes for this entry
     warehouse_name VARCHAR(255) NOT NULL, -- Warehouse name (from Damasco's 'whsName')

--- a/namwoo_app/models/product.py
+++ b/namwoo_app/models/product.py
@@ -52,6 +52,11 @@ class Product(Base):
     llm_summarized_description = Column(
         Text, nullable=True, comment="LLM-generated summary of the description"
     )
+    especificacion = Column(
+        Text,
+        nullable=True,
+        comment="Detailed product specifications",
+    )
 
     # Descriptive attributes
     category = Column(
@@ -134,6 +139,7 @@ class Product(Base):
             "item_name": self.item_name,
             "description": self.description,
             "llm_summarized_description": self.llm_summarized_description,
+            "especificacion": self.especificacion,
             "plain_text_description_derived": strip_html_to_text(
                 self.description or ""
             ),
@@ -188,11 +194,17 @@ class Product(Base):
             else "Descripción no disponible."
         )
 
+        spec_str = (
+            f" Especificaciones: {self.especificacion.strip()}"
+            if self.especificacion and self.especificacion.strip()
+            else ""
+        )
+
         base_info = (
             f"{self.item_name or 'Producto sin nombre'} "
             f"(Marca: {self.brand or 'N/A'}, "
             f"Categoría: {self.category or 'N/A'}). "
-            f"{price_str}{price_bolivar_str}. {desc_str_for_llm}"
+            f"{price_str}{price_bolivar_str}. {desc_str_for_llm}{spec_str}"
         )  # <<< MODIFIED to include price_bolivar_str
 
         if include_stock_location:
@@ -257,6 +269,8 @@ class Product(Base):
 
         if description_content_for_embedding:  # Add only if it's not empty
             add_part(description_content_for_embedding)
+
+        add_part(damasco_product_data.get("especificacion"))
 
         add_part(damasco_product_data.get("category"))
         add_part(damasco_product_data.get("subCategory"))

--- a/namwoo_app/services/damasco_service.py
+++ b/namwoo_app/services/damasco_service.py
@@ -1,6 +1,7 @@
 # NAMWOO/services/damasco_service.py
 import logging
-from decimal import Decimal, InvalidOperation # <<< ADDED for precise price handling
+from decimal import Decimal, InvalidOperation
+from typing import Optional
 
 # Logger for this service
 logger = logging.getLogger('sync')  # Matches sync_service.py logger (or a dedicated one like 'damasco_service')
@@ -56,6 +57,7 @@ def process_damasco_data(raw_data_list: list) -> list:
                 'item_code': str(item.get('itemCode', '')).strip(),
                 'item_name': str(item.get('itemName', '')).strip(),
                 'description': item.get('description'), # Keep as is (raw HTML)
+                'especificacion': item.get('especificacion') or item.get('specification'),
                 'stock': int(item.get('stock', 0)), # Default to 0 if missing/invalid
                 'price': price_usd_decimal, # Store as Decimal (or float if you prefer: float(price_usd_raw or 0.0))
                 'price_bolivar': price_bolivar_decimal, # <<< ADDED new field, store as Decimal

--- a/namwoo_app/services/product_service.py
+++ b/namwoo_app/services/product_service.py
@@ -382,6 +382,9 @@ def add_or_update_product_in_db(
         "item_group_name": _normalize_string(
             damasco_product_data_camel.get("itemGroupName")
         ),
+        "especificacion": _normalize_string(
+            damasco_product_data_camel.get("especificacion")
+        ),
         "warehouse_name": whs_name_raw,
         "branch_name": _normalize_string(damasco_product_data_camel.get("branchName")),
         "price": normalized_price_for_db,
@@ -413,6 +416,7 @@ def add_or_update_product_in_db(
             "brand": insert_stmt.excluded.brand,
             "line": insert_stmt.excluded.line,
             "item_group_name": insert_stmt.excluded.item_group_name,
+            "especificacion": insert_stmt.excluded.especificacion,
             "warehouse_name": insert_stmt.excluded.warehouse_name,
             "branch_name": insert_stmt.excluded.branch_name,
             "price": insert_stmt.excluded.price,


### PR DESCRIPTION
## Summary
- store new `especificacion` text specs on Product ORM
- pass `especificacion` through Celery tasks and product service
- include specs in embedding text preparation and LLM formatting
- extend Damasco data processing for spec field
- document the new column and update schema example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b8685e564832bb28a9c6f64d92a32