### PR TITLE
Fix WhatsApp template sender

### DIFF
--- a/namwoo_app/api/routes.py
+++ b/namwoo_app/api/routes.py
@@ -18,8 +18,7 @@ from ..services import google_service
 # --- Import Support Board service if needed for error replies ---
 from ..services import support_board_service
 from ..services.support_board_service import (
-    send_order_confirmation_template,
-    send_template_by_phone_number,
+    send_whatsapp_template,
     route_conversation_to_sales,
 )
 # Text utilities
@@ -114,10 +113,12 @@ def handle_support_board_webhook():
     customer_user_id_str = str(customer_user_id_str)
 
     if order_vars and isinstance(order_vars, list) and len(order_vars) == 8:
-        send_order_confirmation_template(
-            user_id=customer_user_id_str,
-            conversation_id=sb_conversation_id_str,
-            variables=order_vars,
+        send_whatsapp_template(
+            to=customer_user_id_str,
+            template_name="confirmacion_datos_cliente",
+            template_languages="es_ES",
+            parameters=order_vars,
+            recipient_id=sb_conversation_id_str,
         )
         route_conversation_to_sales(sb_conversation_id_str)
         return (
@@ -260,9 +261,12 @@ def handle_support_board_webhook():
                 ]
                 phone = str(customer_data.get("telefono", "")).strip()
                 if phone:
-                    send_template_by_phone_number(
-                        phone_number=phone,
-                        template_params=params,
+                    send_whatsapp_template(
+                        to=phone,
+                        template_name="confirmacion_datos_cliente",
+                        template_languages="es_ES",
+                        parameters=params,
+                        recipient_id=sb_conversation_id_str,
                     )
                     route_conversation_to_sales(sb_conversation_id_str)
                     return (

--- a/namwoo_app/services/openai_service.py
+++ b/namwoo_app/services/openai_service.py
@@ -365,12 +365,13 @@ def _tool_send_whatsapp_order_summary_template(
     exposed to the LLM for function calling. Any changes require updates in
     both places."""
 
-    phone_e164 = f"+{customer_platform_user_id.lstrip('+')}"
-    ok = _send_whatsapp_template(
-        phone_e164,
+    phone_number = customer_platform_user_id
+    ok = support_board_service.send_whatsapp_template(
+        to=phone_number,
         template_name="confirmacion_datos_cliente",
         template_languages="es_ES",
         parameters=template_variables,
+        recipient_id=conversation_id,
     )
     return {"status": "success" if ok else "failed"}
 

--- a/tests/test_end_to_end_checkout.py
+++ b/tests/test_end_to_end_checkout.py
@@ -68,11 +68,11 @@ spec.loader.exec_module(openai_service)
 def test_end_to_end_checkout(monkeypatch):
     calls = []
 
-    def fake_send(phone, template_name, template_languages, parameters, phone_id=None):
-        calls.append(parameters)
+    def fake_send(**kwargs):
+        calls.append(kwargs.get("parameters"))
         return True
 
-    monkeypatch.setattr(openai_service, "_send_whatsapp_template", fake_send, raising=False)
+    monkeypatch.setattr(openai_service.support_board_service, "send_whatsapp_template", fake_send, raising=False)
 
     res = openai_service._tool_send_whatsapp_order_summary_template(
         customer_platform_user_id="+1234567",


### PR DESCRIPTION
## Summary
- consolidate WhatsApp template sending into `send_whatsapp_template`
- remove old template functions
- use new helper in OpenAI service
- update API routes to use the new sender
- adjust tests for new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c73ec4c78832baf042e02afeee80e