### PR TITLE
Expose full product data

### DIFF
--- a/namwoo_app/models/product.py
+++ b/namwoo_app/models/product.py
@@ -131,9 +131,18 @@ class Product(Base):
             f"warehouse='{self.warehouse_name}', stock={self.stock})>"
         )
 
-    def to_dict(self) -> Dict[str, Any]:  # Explicitly typing return dict
-        """Returns a dictionary representation of the product-location entry."""
-        return {
+    def to_dict(self, include_source: bool = False) -> Dict[str, Any]:
+        """Return a dictionary representation of the product-location entry.
+
+        Parameters
+        ----------
+        include_source:
+            If ``True`` the original ``source_data_json`` column will be
+            included in the returned dictionary.  This field can be quite
+            verbose so it is omitted by default.
+        """
+
+        data = {
             "id": self.id,
             "item_code": self.item_code,
             "item_name": self.item_name,
@@ -157,10 +166,14 @@ class Product(Base):
             ),  # <<< NEW FIELD ADDED
             "stock": self.stock,
             "searchable_text_content": self.searchable_text_content,
-            # "source_data_json": self.source_data_json, # Often too verbose for general dicts unless specifically requested
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
+
+        if include_source:
+            data["source_data_json"] = self.source_data_json
+
+        return data
 
     def format_for_llm(self, include_stock_location: bool = True) -> str:
         """Formats product information for presentation by an LLM, prioritizing LLM summary."""

--- a/namwoo_app/services/product_service.py
+++ b/namwoo_app/services/product_service.py
@@ -202,7 +202,7 @@ def search_local_products(
             logger.debug("DB returned %d rows after final filters", len(rows))
             results: List[Dict[str, Any]] = []
             for prod_location_entry, sim_score in rows:
-                item_dict = prod_location_entry.to_dict()
+                item_dict = prod_location_entry.to_dict(include_source=True)
                 item_dict.update(
                     {
                         "similarity": round(float(sim_score), 4),
@@ -487,7 +487,7 @@ def get_live_product_details_by_sku(
                     f"No product entries found with item_code: {normalized_item_code}"
                 )
                 return []
-            results = [entry.to_dict() for entry in product_entries]
+            results = [entry.to_dict(include_source=True) for entry in product_entries]
             logger.info(
                 f"Found {len(results)} locations for item_code: {normalized_item_code}"
             )
@@ -517,7 +517,7 @@ def get_live_product_details_by_id(composite_id: str) -> Optional[Dict[str, Any]
             if not product_entry:
                 logger.info(f"No product entry found with composite_id: {composite_id}")
                 return None
-            return product_entry.to_dict()
+            return product_entry.to_dict(include_source=True)
         except SQLAlchemyError as db_exc:
             logger.exception(
                 f"DB error fetching product by composite_id: {composite_id}, Error: {db_exc}"

--- a/tests/test_products.py
+++ b/tests/test_products.py
@@ -65,3 +65,67 @@ def test_search_accent_insensitive(session):
     add_prod(session, "SKU1", "Sabana Grande", item_name="licuadora X")
     res = session.search(["Sabána Grande"])
     assert res, "Should find rows regardless of accent / case"
+
+
+def test_product_to_dict_includes_source_data():
+    PRODUCT_PATH = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "namwoo_app", "models", "product.py")
+    )
+    spec = importlib.util.spec_from_file_location("namwoo_app.models.product", PRODUCT_PATH)
+    product_mod = importlib.util.module_from_spec(spec)
+    product_mod.__package__ = "namwoo_app.models"
+    # Stub pgvector.sqlalchemy.Vector to avoid dependency
+    import types, sys
+    fake_pgvector_sqlalchemy = types.ModuleType("pgvector.sqlalchemy")
+    fake_pgvector_sqlalchemy.Vector = lambda *a, **k: None
+    sys.modules.setdefault("pgvector.sqlalchemy", fake_pgvector_sqlalchemy)
+
+    fake_sqlalchemy = types.ModuleType("sqlalchemy")
+    fake_sqlalchemy.NUMERIC = fake_sqlalchemy.TIMESTAMP = lambda *a, **k: None
+    fake_sqlalchemy.Integer = lambda *a, **k: None
+    fake_sqlalchemy.String = lambda *a, **k: None
+    fake_sqlalchemy.Text = lambda *a, **k: None
+    fake_sqlalchemy.UniqueConstraint = lambda *a, **k: None
+    fake_sqlalchemy.Column = lambda *a, **k: None
+    fake_sqlalchemy.func = types.SimpleNamespace(now=lambda: None)
+    sys.modules.setdefault("sqlalchemy", fake_sqlalchemy)
+    fake_pg = types.ModuleType("sqlalchemy.dialects.postgresql")
+    fake_pg.JSONB = object
+    sys.modules.setdefault("sqlalchemy.dialects", types.ModuleType("sqlalchemy.dialects"))
+    sys.modules.setdefault("sqlalchemy.dialects.postgresql", fake_pg)
+    # Minimal config package to satisfy relative imports
+    config_pkg = types.ModuleType("namwoo_app.config")
+    config_mod = types.ModuleType("namwoo_app.config.config")
+    class DummyConfig:
+        pass
+    config_mod.Config = DummyConfig
+    sys.modules.setdefault("namwoo_app", types.ModuleType("namwoo_app"))
+    sys.modules.setdefault("namwoo_app.config", config_pkg)
+    sys.modules.setdefault("namwoo_app.config.config", config_mod)
+    config_pkg.Config = DummyConfig
+    utils_pkg = types.ModuleType("namwoo_app.utils")
+    text_utils_mod = types.ModuleType("namwoo_app.utils.text_utils")
+    text_utils_mod.strip_html_to_text = lambda x: x
+    sys.modules.setdefault("namwoo_app.utils", utils_pkg)
+    sys.modules.setdefault("namwoo_app.utils.text_utils", text_utils_mod)
+    models_pkg = types.ModuleType("namwoo_app.models")
+    models_pkg.Base = object
+    sys.modules.setdefault("namwoo_app.models", models_pkg)
+
+    spec.loader.exec_module(product_mod)
+    Product = product_mod.Product
+
+    p = Product()
+    p.id = "abc@main"
+    p.item_code = "ABC"
+    p.item_name = "Test Product"
+    p.warehouse_name = "Main"
+    p.warehouse_name_canonical = "main"
+    p.stock = 1
+    p.source_data_json = {"foo": "bar"}
+
+    default_dict = p.to_dict()
+    assert "source_data_json" not in default_dict
+
+    with_source = p.to_dict(include_source=True)
+    assert with_source["source_data_json"] == {"foo": "bar"}


### PR DESCRIPTION
## Summary
- add `include_source` option to `Product.to_dict`
- return source data in search results and detail lookups
- test that products can include source data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684cc978f54c832b9bb25fcd51fd726c