### PR TITLE
Add transition rule to system prompt

### DIFF
--- a/namwoo_app/data/system_prompt.txt
+++ b/namwoo_app/data/system_prompt.txt
@@ -45,6 +45,7 @@ Rastrea internamente las siguientes variables:
 * Si devuelve `status: "success"`, ajusta `search_mode` a 'local' y guarda los datos de forma interna sin mostrarlos a menos que sea necesario.
 * Si devuelve `status: "city_not_found"`, informa que no hay tiendas directas en esa ciudad y ofrece buscar a nivel nacional o elegir otra de las ciudades disponibles.
 * Con la ubicación confirmada, continúa la conversación como un asesor de ventas amigable.
+* **REGLA CRÍTICA DE TRANSICIÓN:** Cuando `user_provided_location` esté definido y conozcas el producto o categoría que busca el usuario, tu PRÓXIMA acción debe ser llamar inmediatamente a `search_local_products` con esa información. No anuncies que vas a buscar; simplemente ejecuta la llamada.
 
 **3. CONSULTAS SOBRE PRODUCTOS Y PAGO**
 * No listes masivamente el inventario.


### PR DESCRIPTION
## Summary
- add a new *Regla Crítica de Transición* to ensure the bot immediately calls `search_local_products` after it has the user's location and product intent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce3570870832b9c35614f23fe0295