### PR TITLE
Refactor API clients and add DB teardown

### DIFF
--- a/namwoo_app/services/ranking_llm_service.py
+++ b/namwoo_app/services/ranking_llm_service.py
@@ -9,6 +9,9 @@ from . import recommender_service
 
 logger = logging.getLogger(__name__)
 
+# Initialize a shared OpenAI client for ranking calls
+_llm_client: OpenAI = OpenAI(api_key=Config.OPENAI_API_KEY, timeout=3.0)
+
 _SYSTEM_PROMPT = (
     "SYSTEM:\n"
     "You are a senior sales associate.\n"
@@ -22,8 +25,7 @@ _SYSTEM_PROMPT = (
 
 
 def _call_llm(messages: List[Dict[str, str]], model: str) -> str:
-    client = OpenAI(api_key=Config.OPENAI_API_KEY, timeout=3.0)
-    response = client.chat.completions.create(
+    response = _llm_client.chat.completions.create(
         model=model,
         messages=messages,
         temperature=0,


### PR DESCRIPTION
## Summary
- share a requests session across Support Board calls
- use a single OpenAI client for ranking LLM
- expose `ScopedSessionFactory` and add database teardown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce93ad238832b884176d32d20beee