### PR TITLE
Trim product specs and add tests

### DIFF
--- a/namwoo_app/services/openai_service.py
+++ b/namwoo_app/services/openai_service.py
@@ -21,6 +21,13 @@ try:  # Optional import for testing environments
 except Exception:  # pragma: no cover - fallback for stripped test modules
     def canonicalize_whs_name(name):
         return name
+
+# Re-export helper for backward compatibility in tests
+try:
+    user_is_asking_for_cheapest = product_utils.user_is_asking_for_cheapest
+except AttributeError:  # pragma: no cover - stubbed in tests
+    def user_is_asking_for_cheapest(message: str) -> bool:
+        return False
 import re
 
 

--- a/tests/test_cheapest_detection.py
+++ b/tests/test_cheapest_detection.py
@@ -53,6 +53,18 @@ sys.modules.setdefault('namwoo_app.services.support_board_service', types.Module
 sys.modules.setdefault('namwoo_app.utils.embedding_utils', types.ModuleType('eu'))
 sys.modules.setdefault('namwoo_app.utils.conversation_location', types.ModuleType('cl'))
 sys.modules.setdefault('namwoo_app.services.product_recommender', types.ModuleType('pr'))
+pu_mod = types.ModuleType('pu')
+def cheap(msg):
+    if not msg:
+        return False
+    words = [
+        "mas barato", "más barato", "mas economico", "más económico",
+        "menor precio", "menos costoso", "mas bajo", "más bajo",
+    ]
+    msg = msg.lower()
+    return any(w in msg for w in words)
+pu_mod.user_is_asking_for_cheapest = cheap
+sys.modules.setdefault('namwoo_app.utils.product_utils', pu_mod)
 
 config_pkg = types.ModuleType('namwoo_app.config')
 config_pkg.__path__ = []

--- a/tests/test_end_to_end_checkout.py
+++ b/tests/test_end_to_end_checkout.py
@@ -42,6 +42,18 @@ sys.modules.setdefault('namwoo_app.utils', utils_pkg)
 sys.modules.setdefault('namwoo_app.utils.embedding_utils', types.ModuleType('eu'))
 sys.modules.setdefault('namwoo_app.utils.conversation_location', types.ModuleType('cl'))
 sys.modules.setdefault('namwoo_app.services.product_recommender', types.ModuleType('pr'))
+pu_mod = types.ModuleType('pu')
+def cheap(msg):
+    if not msg:
+        return False
+    words = [
+        "mas barato", "más barato", "mas economico", "más económico",
+        "menor precio", "menos costoso", "mas bajo", "más bajo",
+    ]
+    msg = msg.lower()
+    return any(w in msg for w in words)
+pu_mod.user_is_asking_for_cheapest = cheap
+sys.modules.setdefault('namwoo_app.utils.product_utils', pu_mod)
 config_pkg = types.ModuleType('namwoo_app.config')
 config_mod = types.ModuleType('namwoo_app.config.config')
 class DummyConfig:

--- a/tests/test_product_utils.py
+++ b/tests/test_product_utils.py
@@ -76,3 +76,20 @@ def test_format_product_response_and_brand_list():
     brand_message = format_brand_list(["XIAOMI", "TECNO", "SAMSUNG"])
     assert brand_message.startswith("📱 Estas son las marcas")
     assert "🔹 SAMSUNG" in brand_message
+
+
+def test_get_key_specs_truncates_especificacion():
+    long_spec = "a" * 250 + "\nsecond line should be ignored"
+    product = {"especificacion": long_spec}
+    result = product_utils._get_key_specs(product)
+    assert len(result) == 200
+    assert "second line" not in result
+
+
+def test_get_key_specs_truncates_llm_summary():
+    long_summary = "Esta es una oracion muy larga " + ("b" * 240) + ". Otra oracion que no debe aparecer."
+    product = {"llm_summarized_description": long_summary}
+    result = product_utils._get_key_specs(product)
+    assert len(result) == 200
+    assert "Otra oracion" not in result
+


### PR DESCRIPTION
## Summary
- add compatibility helpers in tests
- expose extract_color_from_name and get_available_brands
- trim long spec strings in `_get_key_specs`
- improve `format_product_response` field fallbacks
- alias user_is_asking_for_cheapest in service for tests
- add tests to ensure spec truncation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e707a8cb4832ba63d548080e634f7