### PR TITLE
Implement WhatsApp checkout routing

### DIFF
--- a/namwoo_app/services/product_recommender.py
+++ b/namwoo_app/services/product_recommender.py
@@ -96,7 +96,14 @@ def rank_products(user_intent: str, candidates: List[Dict[str, Any]], top_n: int
                 response_format={"type": "json_object"},
             )
             content = response.choices[0].message.content
-            recommendations = json.loads(content).get("recommendations", [])
+            data = json.loads(content)
+            recommendations = data.get("recommendations")
+            if recommendations is None:
+                ordered = data.get("ordered_skus")
+                if ordered:
+                    recommendations = [{"sku": s} for s in ordered]
+                else:
+                    recommendations = []
 
             enriched_candidates = []
             # Use the LLM's ordering and enrichment


### PR DESCRIPTION
## Summary
- add fallback Flask context import
- enrich WhatsApp template sending helper with live pricing
- expose WhatsApp template API helpers
- check recent template to route WhatsApp conversations
- add helper for product specs and price formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851194d7204832b8bf92f20ea781d7c