### PR TITLE
Fix WAID fallback when sending WhatsApp template

### DIFF
--- a/namwoo_app/services/openai_service.py
+++ b/namwoo_app/services/openai_service.py
@@ -740,6 +740,12 @@ def process_new_message(
         )
         return
 
+    try:
+        g.customer_user_id = customer_user_id
+        g.conversation_id = sb_conversation_id
+    except Exception:
+        pass
+
     logger.info(
         "Processing message for SB Conv %s (trigger_user=%s, customer=%s, source=%s, trig_msg_id=%s)",
         sb_conversation_id, sender_user_id, customer_user_id, conversation_source, triggering_message_id,
@@ -989,3 +995,8 @@ def process_new_message(
             source=conversation_source, target_user_id=customer_user_id,
             conversation_details=conversation_data, triggering_message_id=triggering_message_id,
         )
+    try:
+        g.customer_user_id = None
+        g.conversation_id = None
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary
- add helper `_normalize_phone_number` for raw numbers
- allow `send_whatsapp_template_direct` to treat unknown user IDs as phone numbers
- store conversation context in `process_new_message` for template tool cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68511f652458832b8947ecff354c8fc6