### PR TITLE
Canonicalize warehouse names on ingest

### DIFF
--- a/namwoo_app/celery_tasks.py
+++ b/namwoo_app/celery_tasks.py
@@ -17,6 +17,7 @@ from .celery_app import celery_app, FlaskTask
 from .services import product_service, openai_service
 from .services import llm_processing_service
 from .utils import db_utils, text_utils # text_utils is used by Product model
+from .utils.whs_utils import canonicalize_whs_name
 from .models.product import Product
 from .config import Config
 
@@ -118,7 +119,8 @@ def _normalize_string_for_id_parts(value: Any) -> Optional[str]:
 
 def _generate_product_location_id(item_code: str, warehouse_name: str) -> Optional[str]:
     norm_item_code = _normalize_string_for_id_parts(item_code)
-    norm_whs_name = _normalize_string_for_id_parts(warehouse_name)
+    canonical_name = canonicalize_whs_name(_normalize_string_for_id_parts(warehouse_name))
+    norm_whs_name = _normalize_string_for_id_parts(canonical_name)
 
     if not norm_item_code or not norm_whs_name: # Pydantic should ensure these are non-empty strings
         logger.error(f"ID Generation Error: item_code ('{item_code}') or whs_name ('{warehouse_name}') became empty. This is unexpected after Pydantic validation.")

--- a/namwoo_app/utils/product_utils.py
+++ b/namwoo_app/utils/product_utils.py
@@ -100,10 +100,23 @@ def _normalize_string_for_id_part(value: Any) -> Optional[str]:
     return s if s else None
 
 
+try:
+    from .whs_utils import canonicalize_whs_name
+except Exception:  # pragma: no cover - allow standalone usage without package
+    def canonicalize_whs_name(name):
+        return name
+
+
 def generate_product_location_id(item_code_raw: Any, whs_name_raw: Any) -> Optional[str]:
-    """Generates the composite product ID consistently."""
+    """Generates the composite product ID consistently.
+
+    The warehouse name is first mapped to its canonical form using
+    :func:`canonicalize_whs_name` so that IDs remain stable across
+    slightly different warehouse representations.
+    """
     item_code = _normalize_string_for_id_part(item_code_raw)
-    whs_name = _normalize_string_for_id_part(whs_name_raw)
+    canonical_whs_name = canonicalize_whs_name(_normalize_string_for_id_part(whs_name_raw))
+    whs_name = _normalize_string_for_id_part(canonical_whs_name)
     if not item_code or not whs_name:
         return None
     sanitized_whs_name = re.sub(r'[^a-zA-Z0-9_-]', '_', whs_name)

--- a/tests/test_product_utils.py
+++ b/tests/test_product_utils.py
@@ -13,6 +13,13 @@ get_available_brands = product_utils.get_available_brands
 format_product_response = product_utils.format_product_response
 format_brand_list = product_utils.format_brand_list
 
+WH_UTILS_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "namwoo_app", "utils", "whs_utils.py"))
+wh_spec = importlib.util.spec_from_file_location("whs_utils", WH_UTILS_PATH)
+whs_utils = importlib.util.module_from_spec(wh_spec)
+wh_spec.loader.exec_module(whs_utils)
+canonicalize_whs_name = whs_utils.canonicalize_whs_name
+product_utils.canonicalize_whs_name = canonicalize_whs_name
+
 
 def test_generate_product_location_id_basic():
     assert generate_product_location_id("ABC123", "Main Warehouse") == "ABC123_Main_Warehouse"
@@ -126,4 +133,13 @@ def test_user_is_asking_for_list_detection():
     ]
     for msg in non_list_msgs:
         assert not product_utils.user_is_asking_for_list(msg)
+
+
+def test_generate_product_location_id_canonicalizes_branch():
+    result = generate_product_location_id("SKU1", "CCCT")
+    assert result == "SKU1_Almacen_Principal_CCCT"
+
+
+def test_canonicalize_whs_name_maps_branch():
+    assert canonicalize_whs_name("CCCT") == "Almacen Principal CCCT"
 


### PR DESCRIPTION
## Summary
- ensure generated product IDs use canonical warehouse names
- normalize incoming warehouse names before saving to DB
- apply the same mapping when creating IDs in celery task
- expose canonical name helper in tests and verify mapping

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534789988c832b8161619ea3042c88