### PR TITLE
Improve color variant detection for products

### DIFF
--- a/namwoo_app/services/google_service.py
+++ b/namwoo_app/services/google_service.py
@@ -169,14 +169,17 @@ def _tool_get_color_variants(product_identifier: str) -> str:
     variants = product_service.get_color_variants(product_identifier)
     if variants is None:
         return json.dumps({"status": "error", "message": "No se pudo buscar variantes."}, ensure_ascii=False)
-    
+
     color_names = set()
     for sku in variants:
-        color, _ = product_utils.extract_color_from_name(sku)
-        if color:
-            color_names.add(color)
+        details_list = product_service.get_live_product_details_by_sku(sku)
+        if details_list:
+            item_name = details_list[0].get("item_name") or details_list[0].get("itemName", "")
+            color, _ = product_utils.extract_color_from_name(item_name)
+            if color:
+                color_names.add(color)
 
-    final_list = sorted(list(color_names)) if color_names else variants
+    final_list = sorted(color_names) if color_names else variants
     return json.dumps({"status": "success" if final_list else "not_found", "variants": final_list}, ensure_ascii=False, indent=2)
 
 # --- Tool Schema (Feature-Parity with openai_service.py) ---

--- a/namwoo_app/services/openai_service.py
+++ b/namwoo_app/services/openai_service.py
@@ -337,16 +337,19 @@ def _tool_get_color_variants(product_identifier: str) -> str:
     variants = product_service.get_color_variants(product_identifier)
     if variants is None:
         return json.dumps({"status": "error", "message": "No se pudo buscar variantes."}, ensure_ascii=False)
-    
-    # After getting the variant SKUs, we get the color names for a user-friendly response.
+
+    # Map variant SKUs to color names by fetching each product's details.
     color_names = set()
     for sku in variants:
-        color, _ = product_utils.extract_color_from_name(sku)
-        if color:
-            color_names.add(color)
+        details_list = product_service.get_live_product_details_by_sku(item_code_query=sku)
+        if details_list:
+            item_name = details_list[0].get("item_name") or details_list[0].get("itemName", "")
+            color, _ = product_utils.extract_color_from_name(item_name)
+            if color:
+                color_names.add(color)
 
     # If SKUs were found but no colors could be extracted, return the SKUs themselves.
-    final_list = sorted(list(color_names)) if color_names else variants
+    final_list = sorted(color_names) if color_names else variants
 
     return json.dumps({"status": "success" if final_list else "not_found", "variants": final_list}, ensure_ascii=False, indent=2)
 

--- a/namwoo_app/services/product_service.py
+++ b/namwoo_app/services/product_service.py
@@ -48,16 +48,11 @@ def _extract_main_type(text: str) -> str:
     return m.group(0).lower() if m else ""
 
 def _extract_color_from_name(item_name: str) -> Optional[str]:
-    """Extracts a color from the end of a product name string."""
+    """Extract a color from a product name using the shared utility."""
     if not item_name:
         return None
-    # This pattern should match colors at the very end of the string.
-    COLOR_EXTRACT_PAT = re.compile(
-        r'\b(NEGRO|BLANCO|AZUL|VERDE|ROJO|GRIS|DORADO|PLATEADO|PURPURA|MORADO|AMARILLO|NARANJA|PLATA|GRAFITO|ROSADO|PERLADO)$',
-        flags=re.IGNORECASE
-    )
-    match = COLOR_EXTRACT_PAT.search(item_name.upper())
-    return match.group(1).capitalize() if match else None
+    # Delegate to the robust implementation in product_utils for consistency.
+    return product_utils._extract_color_from_name(item_name)
 
 
 # --- Search Products ---

--- a/tests/test_color_variants_tool.py
+++ b/tests/test_color_variants_tool.py
@@ -1,0 +1,90 @@
+import importlib.util
+import sys
+import types
+import os
+import json
+from pathlib import Path
+
+# Minimal environment for importing openai_service
+dummy_openai = types.ModuleType('openai')
+dummy_openai.OpenAI = object
+dummy_openai.APIError = Exception
+dummy_openai.RateLimitError = Exception
+dummy_openai.APITimeoutError = Exception
+dummy_openai.BadRequestError = Exception
+sys.modules.setdefault('openai', dummy_openai)
+
+flask_mod = types.ModuleType('flask')
+flask_mod.Flask = lambda *a, **k: None
+flask_mod.current_app = types.SimpleNamespace(config={})
+sys.modules.setdefault('flask', flask_mod)
+
+dotenv_mod = types.ModuleType('dotenv')
+dotenv_mod.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault('dotenv', dotenv_mod)
+
+pkg = types.ModuleType('namwoo_app')
+pkg.__path__ = []
+services_pkg = types.ModuleType('namwoo_app.services')
+services_pkg.__path__ = []
+pkg.services = services_pkg
+sys.modules.setdefault('namwoo_app', pkg)
+sys.modules.setdefault('namwoo_app.services', services_pkg)
+
+ps_mod = types.ModuleType('ps')
+sys.modules.setdefault('namwoo_app.services.product_service', ps_mod)
+sys.modules.setdefault('namwoo_app.services.support_board_service', types.ModuleType('sb'))
+sys.modules.setdefault('namwoo_app.services.product_recommender', types.ModuleType('pr'))
+utils_pkg = types.ModuleType('namwoo_app.utils')
+utils_pkg.__path__ = []
+sys.modules.setdefault('namwoo_app.utils', utils_pkg)
+sys.modules.setdefault('namwoo_app.utils.embedding_utils', types.ModuleType('eu'))
+sys.modules.setdefault('namwoo_app.utils.conversation_location', types.ModuleType('cl'))
+pu_mod = types.ModuleType('pu')
+pu_mod.extract_color_from_name = lambda name: (name.split()[-1].capitalize(), '')
+sys.modules.setdefault('namwoo_app.utils.product_utils', pu_mod)
+
+config_pkg = types.ModuleType('namwoo_app.config')
+config_mod = types.ModuleType('namwoo_app.config.config')
+class DummyConfig:
+    OPENAI_API_KEY = None
+    MAX_HISTORY_MESSAGES = 16
+    OPENAI_CHAT_MODEL = 'gpt-4o-mini'
+    OPENAI_MAX_TOKENS = 1024
+    OPENAI_TEMPERATURE = 0.7
+config_mod.Config = DummyConfig
+sys.modules['namwoo_app.config.config'] = config_mod
+sys.modules['namwoo_app.config'] = config_pkg
+config_pkg.Config = DummyConfig
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+spec = importlib.util.spec_from_file_location(
+    'namwoo_app.services.openai_service',
+    os.path.join('namwoo_app', 'services', 'openai_service.py')
+)
+openai_service = importlib.util.module_from_spec(spec)
+openai_service.__package__ = 'namwoo_app.services'
+sys.modules[spec.name] = openai_service
+spec.loader.exec_module(openai_service)
+
+openai_service.product_utils = types.SimpleNamespace(
+    extract_color_from_name=lambda name: (name.split()[-1].capitalize(), '')
+)
+
+
+def test_get_color_variants_maps_skus(monkeypatch):
+    monkeypatch.setattr(openai_service.product_service, 'get_color_variants', lambda ident: ['A1', 'A2'], raising=False)
+
+    def fake_details(sku=None, **kw):
+        code = sku or kw.get('item_code_query')
+        if code == 'A1':
+            return [{'item_name': 'TECNO CAMON 40 PRO BLANCO'}]
+        return [{'item_name': 'TECNO CAMON 40 PRO NEGRO'}]
+
+    monkeypatch.setattr(openai_service.product_service, 'get_live_product_details_by_sku', fake_details, raising=False)
+
+    out = openai_service._tool_get_color_variants('TECNO CAMON 40 PRO')
+    data = json.loads(out)
+    assert data['status'] == 'success'
+    assert sorted(data['variants']) == ['Blanco', 'Negro']

--- a/tests/test_product_utils.py
+++ b/tests/test_product_utils.py
@@ -63,6 +63,13 @@ def test_extract_color_from_name():
     assert base == "PARLANTE"
 
 
+def test_extract_color_with_extra_words():
+    text = "TECNO CAMON 40 256+8 BLANCO + OBSEQUIO"
+    color, base = extract_color_from_name(text)
+    assert color == "Blanco"
+    assert base == "TECNO CAMON 40"
+
+
 def test_group_products_by_model_and_brands():
     items = [
         {"itemName": "INFINIX HOT 50 NEGRO", "brand": "INFINIX", "price": 240},


### PR DESCRIPTION
## Summary
- delegate product color extraction to shared utilities
- map color variants using product names rather than SKU codes
- support extra words like `OBSEQUIO` in color extraction
- add regression tests for color utils and tool behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68536290e010832ba879e92f9e4b57ef