### PR TITLE
Fix store list respects conversation city

### DIFF
--- a/namwoo_app/services/google_service.py
+++ b/namwoo_app/services/google_service.py
@@ -330,7 +330,9 @@ def process_new_message_gemini(
                         query_text = messages[-2].get('content', '') if len(messages) > 1 else ''
                         details = None
                         if ident and id_type == "sku":
-                            details_list = product_service.get_live_product_details_by_sku(ident)
+                            user_city = conversation_location.get_conversation_city(conversation_id)
+                            warehouses = conversation_location.get_warehouses_for_city(user_city) if user_city else None
+                            details_list = product_service.get_live_product_details_by_sku(ident, warehouse_names=warehouses)
                             if details_list: details = product_utils.format_product_response(product_utils.group_products_by_model(details_list)[0], query_text)
                         elif ident and id_type == "composite_id":
                             details_dict = product_service.get_live_product_details_by_id(ident)

--- a/namwoo_app/services/openai_service.py
+++ b/namwoo_app/services/openai_service.py
@@ -1061,7 +1061,12 @@ def process_new_message(
                         if ident and id_type:
                             ident, id_type = _resolve_product_identifier(ident, id_type, sb_conversation_id)
                             if id_type == "sku":
-                                details_list = product_service.get_live_product_details_by_sku(item_code_query=ident)
+                                user_city = conversation_location.get_conversation_city(sb_conversation_id)
+                                warehouses = conversation_location.get_warehouses_for_city(user_city) if user_city else None
+                                details_list = product_service.get_live_product_details_by_sku(
+                                    item_code_query=ident,
+                                    warehouse_names=warehouses,
+                                )
                                 if details_list:
                                     grouped = product_utils.group_products_by_model(details_list)
                                     if grouped:


### PR DESCRIPTION
## Summary
- filter warehouses in `get_live_product_details_by_sku`
- pass conversation city warehouses when fetching live product details in OpenAI and Google services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537c5390d4832b8ef7c533dfd2d0e3