### PR TITLE
Fix price intent detection and routing

### DIFF
--- a/namwoo_app/data/system_prompt.txt
+++ b/namwoo_app/data/system_prompt.txt
@@ -1,5 +1,10 @@
 Eres Damasco Tecno, un asistente de ventas virtual para una tienda de tecnología. Tu especialidad es ayudar a los clientes a encontrar los mejores productos electrónicos, como audífonos, celulares, routers, cámaras, cargadores de teléfono, relojes inteligentes y otros accesorios. Tu función es guiar a los clientes de forma amable y eficiente.
 
+**REGLA CRÍTICA #2: DISTINCIÓN DE INTENTOS DE BÚSQUEDA**
+*   **Si el usuario pregunta por el precio de un solo producto**, muestra solo ese modelo sin sugerir alternativas, salvo que no se encuentre.
+*   **Si la pregunta es abierta o comparativa**, presenta de dos a tres recomendaciones con sus razones.
+*   **Si solicita una lista completa**, entrega los modelos disponibles de forma breve.
+
 **REGLA CRÍTICA #1: MANEJO DE RESPUESTAS DE HERRAMIENTAS**
 *   **Texto Pre-formateado:** Cuando una herramienta (como `search_local_products` o `get_available_brands`) te devuelve un texto ya formateado para el cliente en el campo `formatted_response`, **DEBES** presentar ese texto al usuario **EXACTAMENTE** como te fue entregado. No lo alteres, no lo resumas, no añadas introducciones como "Claro, aquí tienes..." ni lo reformules de ninguna manera. Simplemente entrégalo tal cual.
 *   **Resultados No Encontrados:** Si una herramienta devuelve `{"status": "not_found"}` o una lista de productos vacía, **NO** digas "no encontré nada" o "no lo tenemos". En su lugar, usa un lenguaje suave y proactivo, por ejemplo: "Hmm, no encontré un resultado exacto para eso. ¿Podrías darme más detalles o te gustaría ver algunas alternativas populares como [mencionar un producto o categoría similar]?".

--- a/namwoo_app/utils/product_utils.py
+++ b/namwoo_app/utils/product_utils.py
@@ -87,26 +87,24 @@ def user_is_asking_for_price(message: str) -> bool:
     if not message:
         return False
     PRICE_KEYWORDS = [
-        "precio de",
-        "precio del",
-        "cual es el precio",
-        "cuanto cuesta",
-        "cuánto cuesta",
-        "que precio tiene",
-        "que precio tiene el",
-        "que precio tienes",
-        "qué precio tiene",
-        "qué precio tienes",
+        "precio",
+        "cuanto",
+        "cuánto",
+        "cuesta",
+        "cuestan",
+        "costo",
+        "valor",
+        "sale en",
         "dime el precio",
-        "price of",
-        "how much is",
-        "how much does",
-        "cost of",
-        "cost for",
+        "que precio",
+        "qué precio",
+        "price",
+        "how much",
+        "cost",
     ]
     import unicodedata
     normalized = unicodedata.normalize("NFKD", message).encode("ascii", "ignore").decode().lower()
-    return any(kw in normalized for kw in PRICE_KEYWORDS)
+    return any(re.search(r"\b" + re.escape(kw) + r"\b", normalized) for kw in PRICE_KEYWORDS)
 
 def user_is_asking_for_best(message: str) -> bool:
     """Return True if the user is asking which option is the best."""

--- a/tests/test_price_request_routing.py
+++ b/tests/test_price_request_routing.py
@@ -1,0 +1,89 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# Minimal openai and flask stubs
+dummy_openai = types.ModuleType('openai')
+dummy_openai.OpenAI = object
+for n in ['APIError', 'RateLimitError', 'APITimeoutError', 'BadRequestError']:
+    setattr(dummy_openai, n, Exception)
+sys.modules.setdefault('openai', dummy_openai)
+
+flask_mod = types.ModuleType('flask')
+flask_mod.Flask = lambda *a, **k: None
+flask_mod.current_app = types.SimpleNamespace(config={})
+sys.modules.setdefault('flask', flask_mod)
+
+dotenv_mod = types.ModuleType('dotenv')
+dotenv_mod.load_dotenv = lambda *a, **k: None
+sys.modules.setdefault('dotenv', dotenv_mod)
+
+pkg = types.ModuleType('namwoo_app')
+pkg.__path__ = []
+services_pkg = types.ModuleType('namwoo_app.services')
+services_pkg.__path__ = []
+pkg.services = services_pkg
+sys.modules.setdefault('namwoo_app', pkg)
+sys.modules.setdefault('namwoo_app.services', services_pkg)
+
+sys.modules.setdefault('namwoo_app.services.support_board_service', types.ModuleType('sb'))
+sys.modules.setdefault('namwoo_app.services.product_service', types.ModuleType('ps'))
+pr_mod = types.ModuleType('namwoo_app.services.product_recommender')
+pr_mod.rank_products = lambda user_intent=None, candidates=None, sort_by=None: candidates or []
+sys.modules.setdefault('namwoo_app.services.product_recommender', pr_mod)
+sys.modules.setdefault('namwoo_app.utils.embedding_utils', types.ModuleType('eu'))
+sys.modules.setdefault('namwoo_app.utils.conversation_location', types.ModuleType('cl'))
+
+config_pkg = types.ModuleType('namwoo_app.config')
+config_mod = types.ModuleType('namwoo_app.config.config')
+class DummyConfig:
+    OPENAI_API_KEY = None
+    MAX_HISTORY_MESSAGES = 16
+    OPENAI_CHAT_MODEL = 'gpt-4o-mini'
+    OPENAI_MAX_TOKENS = 1024
+    OPENAI_TEMPERATURE = 0.7
+config_mod.Config = DummyConfig
+sys.modules['namwoo_app.config.config'] = config_mod
+sys.modules['namwoo_app.config'] = config_pkg
+config_pkg.Config = DummyConfig
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+spec = importlib.util.spec_from_file_location(
+    'namwoo_app.services.openai_service',
+    Path(__file__).resolve().parents[1] / 'namwoo_app' / 'services' / 'openai_service.py'
+)
+openai_service = importlib.util.module_from_spec(spec)
+openai_service.__package__ = 'namwoo_app.services'
+sys.modules[spec.name] = openai_service
+spec.loader.exec_module(openai_service)
+
+
+def test_price_query_returns_single_card(monkeypatch):
+    items = [
+        {"item_name": "SAMSUNG A16 NEGRO", "price": 150, "priceBolivar": 15000},
+        {"item_name": "SAMSUNG A26 NEGRO", "price": 170, "priceBolivar": 17000},
+    ]
+    # simple grouping and formatting
+    def fake_group(products):
+        p = products[0]
+        return [{"model": p["item_name"], "price": p["price"], "priceBolivar": p["priceBolivar"], "colors": [], "description": "", "store": "CCS"}]
+
+    formatted = []
+    def fake_format(group, query):
+        formatted.append(group["model"])
+        return f"CARD {group['model']}"
+
+    monkeypatch.setattr(openai_service.product_utils, 'group_products_by_model', fake_group, raising=False)
+    monkeypatch.setattr(openai_service.product_utils, 'format_product_response', fake_format, raising=False)
+
+    result = openai_service._format_search_results(
+        items,
+        'samsung a16',
+        'cuanto cuesta el a16',
+        is_price_request=True,
+        conversation_id='1'
+    )
+    assert result == 'CARD SAMSUNG A16 NEGRO'
+    assert formatted == ['SAMSUNG A16 NEGRO']

--- a/tests/test_product_utils.py
+++ b/tests/test_product_utils.py
@@ -129,6 +129,9 @@ def test_user_is_asking_for_price_detection():
         "precio de D0001234",
         "How much is the iPhone 15?",
         "que precio tienes el samsung a36 blanco?",
+        "Cuánto cuesta el A16?",
+        "En cuanto sale el Samsung A16",
+        "uanto cuesta el samsun a16",
     ]
     for msg in price_msgs:
         assert product_utils.user_is_asking_for_price(msg)


### PR DESCRIPTION
## Summary
- enhance price intent keyword matching
- add helper to format search results
- route price queries to single-item response
- refine system prompt with search intent rule
- expand unit tests and add coverage for price routing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539eabad44832bb7985ff56b7bd494